### PR TITLE
COMP: Fix -Wsign-compare warnings

### DIFF
--- a/Modules/Loadable/Splines/MRML/vtkMRMLMarkupsSplinesNode.cxx
+++ b/Modules/Loadable/Splines/MRML/vtkMRMLMarkupsSplinesNode.cxx
@@ -96,12 +96,12 @@ void vtkMRMLMarkupsSplinesNode::CreateDefaultDisplayNodes()
 //----------------------------------------------------------------------------
 void vtkMRMLMarkupsSplinesNode::SetNthSplineClosed(int n, bool closed)
 {
-  if (n >= this->Closed.size() || this->Closed[n] == closed)
+  if (static_cast<size_t>(n) >= this->Closed.size() || this->Closed[static_cast<size_t>(n)] == closed)
   {
     return;
   }
 
-  this->Closed[n] = closed;
+  this->Closed[static_cast<size_t>(n)] = closed;
   this->Modified();
   this->InvokeCustomModifiedEvent(
     vtkMRMLMarkupsNode::NthMarkupModifiedEvent, (void*)&n);
@@ -110,10 +110,10 @@ void vtkMRMLMarkupsSplinesNode::SetNthSplineClosed(int n, bool closed)
 //----------------------------------------------------------------------------
 bool vtkMRMLMarkupsSplinesNode::GetNthSplineClosed(int n)
 {
-  if (n >= this->Closed.size())
+  if (static_cast<size_t>(n) >= this->Closed.size())
   {
     vtkErrorMacro("The " << n << "th spline doesn't exist");
     return this->DefaultClosed;
   }
-  return this->Closed[n];
+  return this->Closed[static_cast<size_t>(n)];
 }

--- a/Modules/Loadable/Splines/MRMLDM/vtkMRMLMarkupsSplinesDisplayableManager2D.cxx
+++ b/Modules/Loadable/Splines/MRMLDM/vtkMRMLMarkupsSplinesDisplayableManager2D.cxx
@@ -114,7 +114,7 @@ public:
   void ClearDisplayableNodes();
   void ClearPipeline(Pipeline* pipeline);
   vtkSplineWidget2* CreateSplineWidget() const;
-  std::vector<int> EventsToObserve() const;
+  std::vector<unsigned long> EventsToObserve() const;
   void StopInteraction();
 
   bool IsDisplayableOnSlice(vtkMRMLMarkupsSplinesNode* node, int n);
@@ -470,7 +470,7 @@ void vtkMRMLMarkupsSplinesDisplayableManager2D::vtkInternal
   vtkMRMLMarkupsSplinesNode* splinesNode,
   Pipeline* pipeline)
 {
-  size_t numberOfWidgets = pipeline->Widgets.size();
+  int numberOfWidgets = static_cast<int>(pipeline->Widgets.size());
 
   // If we need to remove plane widgets, we don't know which one
   // were deleted, so remove all of them.
@@ -489,9 +489,9 @@ void vtkMRMLMarkupsSplinesDisplayableManager2D::vtkInternal
     }
   }
 
-  for (size_t n = 0; n < pipeline->Widgets.size(); ++n)
+  for (int n = 0; n < static_cast<int>(pipeline->Widgets.size()); ++n)
   {
-    vtkSplineWidget2* widget = pipeline->Widgets[n];
+    vtkSplineWidget2* widget = pipeline->Widgets[static_cast<size_t>(n)];
     bool visible = displayNode->GetVisibility();
     if (visible)
     {
@@ -511,7 +511,7 @@ void vtkMRMLMarkupsSplinesDisplayableManager2D::vtkInternal
     {
       vtkSplineRepresentation* rep =
         vtkSplineRepresentation::SafeDownCast(widget->GetRepresentation());
-      int numberOfPoints = splinesNode->GetNumberOfPointsInNthMarkup(n);
+      int numberOfPoints = splinesNode->GetNumberOfPointsInNthMarkup(static_cast<int>(n));
       rep->SetNumberOfHandles(numberOfPoints);
 
       for (int i = 0; i < numberOfPoints; ++i)
@@ -548,9 +548,9 @@ void vtkMRMLMarkupsSplinesDisplayableManager2D::vtkInternal
     vtkSplineRepresentation::SafeDownCast(widget->GetRepresentation());
 
   Pipeline* pipeline = this->DisplayPipelines[displayNode];
-  size_t index =
-    std::find(pipeline->Widgets.begin(), pipeline->Widgets.end(), widget)
-    - pipeline->Widgets.begin();
+  int index = static_cast<int>(
+        std::find(pipeline->Widgets.begin(), pipeline->Widgets.end(), widget)
+        - pipeline->Widgets.begin());
 
   int wasModifying = splinesNode->StartModify();
 
@@ -612,10 +612,10 @@ void vtkMRMLMarkupsSplinesDisplayableManager2D::vtkInternal
 }
 
 //---------------------------------------------------------------------------
-std::vector<int> vtkMRMLMarkupsSplinesDisplayableManager2D::vtkInternal
+std::vector<unsigned long> vtkMRMLMarkupsSplinesDisplayableManager2D::vtkInternal
 ::EventsToObserve() const
 {
-  std::vector<int> events;
+  std::vector<unsigned long> events;
   events.push_back(vtkMRMLDisplayableNode::DisplayModifiedEvent);
   events.push_back(vtkMRMLMarkupsSplinesNode::MarkupAddedEvent);
   events.push_back(vtkMRMLMarkupsSplinesNode::MarkupRemovedEvent);
@@ -629,7 +629,7 @@ std::vector<int> vtkMRMLMarkupsSplinesDisplayableManager2D::vtkInternal
 void vtkMRMLMarkupsSplinesDisplayableManager2D::vtkInternal
 ::AddObservations(vtkMRMLMarkupsSplinesNode* node)
 {
-  std::vector<int> events = this->EventsToObserve();
+  std::vector<unsigned long> events = this->EventsToObserve();
   vtkEventBroker* broker = vtkEventBroker::GetInstance();
   for (size_t i = 0; i < events.size(); ++i)
   {
@@ -646,7 +646,7 @@ void vtkMRMLMarkupsSplinesDisplayableManager2D::vtkInternal
 {
   vtkEventBroker* broker = vtkEventBroker::GetInstance();
   vtkEventBroker::ObservationVector observations;
-  std::vector<int> events = this->EventsToObserve();
+  std::vector<unsigned long> events = this->EventsToObserve();
   for (size_t i = 0; i < events.size(); ++i)
   {
     observations = broker->GetObservations(node, events[i], this->External, this->External->GetMRMLNodesCallbackCommand());
@@ -847,7 +847,7 @@ void vtkMRMLMarkupsSplinesDisplayableManager2D::UpdateFromMRML()
   int nnodes = scene ? scene->GetNodesByClass("vtkMRMLMarkupsSplinesNode", mNodes) : 0;
   for (int i = 0; i < nnodes; i++)
   {
-    mNode = vtkMRMLMarkupsSplinesNode::SafeDownCast(mNodes[i]);
+    mNode = vtkMRMLMarkupsSplinesNode::SafeDownCast(mNodes[static_cast<size_t>(i)]);
     if (mNode)
     {
       this->Internal->AddNode(mNode);

--- a/Modules/Loadable/Splines/MRMLDM/vtkMRMLMarkupsSplinesDisplayableManager3D.cxx
+++ b/Modules/Loadable/Splines/MRMLDM/vtkMRMLMarkupsSplinesDisplayableManager3D.cxx
@@ -112,7 +112,7 @@ public:
   void ClearDisplayableNodes();
   void ClearPipeline(Pipeline* pipeline);
   vtkSplineWidget2* CreateSplineWidget() const;
-  std::vector<int> EventsToObserve() const;
+  std::vector<unsigned long> EventsToObserve() const;
   void StopInteraction();
 
 public:
@@ -417,7 +417,7 @@ void vtkMRMLMarkupsSplinesDisplayableManager3D::vtkInternal
   vtkMRMLMarkupsSplinesNode* splinesNode,
   Pipeline* pipeline)
 {
-  size_t numberOfWidgets = pipeline->Widgets.size();
+  int numberOfWidgets = static_cast<int>(pipeline->Widgets.size());
 
   // If we need to remove plane widgets, we don't know which one
   // were deleted, so remove all of them.
@@ -436,9 +436,9 @@ void vtkMRMLMarkupsSplinesDisplayableManager3D::vtkInternal
     }
   }
 
-  for (size_t n = 0; n < pipeline->Widgets.size(); ++n)
+  for (int n = 0; n < static_cast<int>(pipeline->Widgets.size()); ++n)
   {
-    vtkSplineWidget2* widget = pipeline->Widgets[n];
+    vtkSplineWidget2* widget = pipeline->Widgets[static_cast<size_t>(n)];
     bool visible = displayNode->GetVisibility();
     if (visible)
     {
@@ -484,9 +484,9 @@ void vtkMRMLMarkupsSplinesDisplayableManager3D::vtkInternal
     vtkSplineRepresentation::SafeDownCast(widget->GetRepresentation());
 
   Pipeline* pipeline = this->DisplayPipelines[displayNode];
-  size_t index =
-    std::find(pipeline->Widgets.begin(), pipeline->Widgets.end(), widget)
-    - pipeline->Widgets.begin();
+  int index = static_cast<int>(
+        std::find(pipeline->Widgets.begin(), pipeline->Widgets.end(), widget)
+        - pipeline->Widgets.begin());
 
   int wasModifying = splinesNode->StartModify();
 
@@ -534,10 +534,9 @@ void vtkMRMLMarkupsSplinesDisplayableManager3D::vtkInternal
 }
 
 //---------------------------------------------------------------------------
-std::vector<int> vtkMRMLMarkupsSplinesDisplayableManager3D::vtkInternal
-::EventsToObserve() const
+std::vector<unsigned long> vtkMRMLMarkupsSplinesDisplayableManager3D::vtkInternal::EventsToObserve() const
 {
-  std::vector<int> events;
+  std::vector<unsigned long> events;
   events.push_back(vtkMRMLDisplayableNode::DisplayModifiedEvent);
   events.push_back(vtkMRMLMarkupsSplinesNode::MarkupAddedEvent);
   events.push_back(vtkMRMLMarkupsSplinesNode::MarkupRemovedEvent);
@@ -551,7 +550,7 @@ std::vector<int> vtkMRMLMarkupsSplinesDisplayableManager3D::vtkInternal
 void vtkMRMLMarkupsSplinesDisplayableManager3D::vtkInternal
 ::AddObservations(vtkMRMLMarkupsSplinesNode* node)
 {
-  std::vector<int> events = this->EventsToObserve();
+  std::vector<unsigned long> events = this->EventsToObserve();
   vtkEventBroker* broker = vtkEventBroker::GetInstance();
   for (size_t i = 0; i < events.size(); ++i)
   {
@@ -568,7 +567,7 @@ void vtkMRMLMarkupsSplinesDisplayableManager3D::vtkInternal
 {
   vtkEventBroker* broker = vtkEventBroker::GetInstance();
   vtkEventBroker::ObservationVector observations;
-  std::vector<int> events = this->EventsToObserve();
+  std::vector<unsigned long> events = this->EventsToObserve();
   for (size_t i = 0; i < events.size(); ++i)
   {
     observations = broker->GetObservations(node, events[i], this->External, this->External->GetMRMLNodesCallbackCommand());
@@ -769,7 +768,7 @@ void vtkMRMLMarkupsSplinesDisplayableManager3D::UpdateFromMRML()
   int nnodes = scene ? scene->GetNodesByClass("vtkMRMLMarkupsSplinesNode", mNodes) : 0;
   for (int i = 0; i < nnodes; i++)
   {
-    mNode = vtkMRMLMarkupsSplinesNode::SafeDownCast(mNodes[i]);
+    mNode = vtkMRMLMarkupsSplinesNode::SafeDownCast(mNodes[static_cast<size_t>(i)]);
     if (mNode)
     {
       this->Internal->AddNode(mNode);


### PR DESCRIPTION
This commit fixes warnings like this one:
```
/home/jcfr/Projects/cell-locator/Modules/Loadable/Splines/MRML/vtkMRMLMarkupsSplinesNode.cxx:99:9: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   if (n >= this->Closed.size() || this->Closed[n] == closed)
         ^
```