### PR TITLE
COMP: Fix Ubuntu 20.04 cpython link error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT DEFINED slicersources_SOURCE_DIR)
   # Download Slicer sources and set variables slicersources_SOURCE_DIR and slicersources_BINARY_DIR
   FetchContent_Populate(slicersources
     GIT_REPOSITORY git://github.com/KitwareMedical/Slicer
-    GIT_TAG        735a05d8e2b806ed29ab64e88b9df42f2f15a2cb # cell-locator-v4.11.0-2018-12-19-0dc589ee5
+    GIT_TAG        0661948e52a7c809002954088bd3a8f847dc888d # cell-locator-v4.11.0-2018-12-19-0dc589ee5
     GIT_PROGRESS   1
     )
 else()


### PR DESCRIPTION
Fixes https://github.com/BICCN/cell-locator/issues/125

List of changes:

$ git shortlog 735a05d8e2..0661948e52 --no-merges
Jean-Christophe Fillion-Robin (1):
      [cell-locator] Fix Ubuntu 20.04 link error updating Python from 2.7.13 to 2.7.15

Co-authored-by: David Allemang <david.allemang@kitware.com>