### PR TITLE
Enable preliminary LIMS support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT DEFINED slicersources_SOURCE_DIR)
   # Download Slicer sources and set variables slicersources_SOURCE_DIR and slicersources_BINARY_DIR
   FetchContent_Populate(slicersources
     GIT_REPOSITORY git://github.com/KitwareMedical/Slicer
-    GIT_TAG        0661948e52a7c809002954088bd3a8f847dc888d # cell-locator-v4.11.0-2018-12-19-0dc589ee5
+    GIT_TAG        9b00dc521fa993d0c3f266890fdae90c3c9945ca # cell-locator-v4.11.0-2018-12-19-0dc589ee5
     GIT_PROGRESS   1
     )
 else()

--- a/Modules/Scripted/Home/Home.py
+++ b/Modules/Scripted/Home/Home.py
@@ -319,7 +319,7 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     body = json.loads(res.read())
 
-    self.loadAnnotationJson(body['data']['data'])
+    self.loadAnnotationJson(body['data'])
 
   def onUploadAnnotationButtonClicked(self):
     logging.info('Upload Annotation Button Clicked')

--- a/Modules/Scripted/Home/Resources/UI/Home.ui
+++ b/Modules/Scripted/Home/Resources/UI/Home.ui
@@ -140,6 +140,22 @@
            </layout>
           </item>
           <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_8">
+            <item>
+             <widget class="QPushButton" name="UploadAnnotationButton">
+              <property name="text">
+               <string>Save to LIMS</string>
+              </property>
+              <property name="icon">
+               <iconset>
+                <normalon>:/Icons/save_icon.svg.png</normalon>
+               </iconset>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
            <widget class="ctkPathLineEdit" name="AnnotationPathLineEdit">
             <property name="enabled">
              <bool>false</bool>


### PR DESCRIPTION
Work for issue #93; tested against a mock LIMS server [KitwareMedical/AllenInstituteMockLIMS](https://github.com/KitwareMedical/AllenInstituteMockLIMS).

There is an associated commit in the KitwareMedical Slicer fork: [KitwareMedical/Slicer#9b00dc5](https://github.com/KitwareMedical/Slicer/commit/9b00dc521fa993d0c3f266890fdae90c3c9945ca).

These add two command-line arguments to CellLocator: `--lims-specimen-id` and `--lims-base-url`. _Both_ must be provided for LIMS functionality to work.

If both arguments are provided, CellLocator will query the LIMS server at `--lims-base-url` for the cell locations of specimen `--lims-specimen-id` and open them as a file. A new button will be enabled, `Save to LIMS`, which will push the changes to the LIMS server.

Currently ISVCC cell count is always assumed to be 1, since CellLocator does not yet support multiple markups on the same specimen.
