### PR TITLE
Migrate LIMS to use requests library

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,14 @@ Infrastructure:
 * Update to Python 3
 * Introduce `Annotation` and `AnnotationManager` classes for interfacing with built-in Slicer markups nodes.
 
+Fixes:
+
+* Improve LIMS integration to address the feedback in [#93](https://github.com/BICCN/cell-locator/issues/93#issuecomment-675102826).
+  * Switch to the `requests` library to properly handle request headers. POST requests use the `json` argument, which sets `Content-Type: application/json`.
+  * Change failure messages to be more helpful. Now includes the error status code and message.
+  For example: `Failed to load annotations for LIMS specimen <ID>. Error <STATUS>: '<REASON>'`
+  * Current LIMS specimen ID is shown in the file path box below "Save to LIMS".
+
 ## Cell Locator 0.1.0 2020-07-30
 
 Features:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,5 +117,9 @@ set(Slicer_EXTENSION_SOURCE_DIRS
 set(Slicer_CTK_GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/KitwareMedical/CTK.git")
 set(Slicer_CTK_GIT_TAG "13ce3d6d99a27c2d7d98cee656fb9c72e2f4e8fc") # cell-locator-2020-07-10-f0bb5d78
 
+set(Slicer_ADDITIONAL_DEPENDENCIES
+  python-requests-requirements
+  )
+
 # Add Slicer sources
 add_subdirectory(${slicersources_SOURCE_DIR} ${slicersources_BINARY_DIR})


### PR DESCRIPTION
Note that this is based on the changes in https://github.com/BICCN/cell-locator/pull/131 so shouldn't be merged until those 
changes are resolved (or should be merged into that PR). I'm just creating a PR here for ease in creating a test installer.

This addresses the feedback in https://github.com/BICCN/cell-locator/issues/93. 

- Switch to the `requests` library to properly handle request headers. POST requests use the `json` argument, which sets `Content-Type: application/json`.
- Change failure messages to be more helpful. Now includes the error status code and message.
  For example: `Failed to load annotations for LIMS specimen <ID>. Error <STATUS>: '<REASON>'`
- Current LIMS specimen ID is shown in the file path box below "Save to LIMS" (screenshot below)

![lims-specimen-display](https://user-images.githubusercontent.com/10702931/90911594-35360e00-e3a7-11ea-821e-82e19af64d84.png)
