### PR TITLE
BUG: Do not set interaction mode if there is no current annotation.

### DIFF
--- a/Modules/Scripted/Home/Home.py
+++ b/Modules/Scripted/Home/Home.py
@@ -1535,6 +1535,9 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     with SignalBlocker(button):
       button.setChecked(True)
 
+    if not self.Annotations.current:
+      return
+
     # 1: update selection node
     markup = self.Annotations.current.markup
     selectionNode = slicer.app.applicationLogic().GetSelectionNode()


### PR DESCRIPTION
`onCurrentItemChanged` will re-set the interaction mode after setting the markup, so this code is still executed when another annotation is added.

Resolves #173.