### PR TITLE
Add Conversion script

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -13,7 +13,8 @@
 import sphinx_rtd_theme
 import os
 import sys
-# sys.path.insert(0, os.path.abspath('.'))
+
+sys.path.insert(0, os.path.abspath('../Scripts/convert'))
 
 
 # -- Project information -----------------------------------------------------
@@ -32,6 +33,8 @@ extensions = [
     'notfound.extension',  # Show a better 404 page when an invalid address is entered
     'sphinx_rtd_theme',
     'myst_parser',
+    'sphinxarg.ext',
+    'sphinx.ext.autodoc',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/Documentation/developer_guide/AnnotationFileConverter.md
+++ b/Documentation/developer_guide/AnnotationFileConverter.md
@@ -1,0 +1,66 @@
+# Annotation File Converter
+
+Since some changes to the file format are backwards-incompatible, we provide a conversion
+utility to update files to newer versions with sensible defaults for new values. The 
+converter can also _downgrade_ file versions, although this is not as thoroughly-tested.
+
+## Commands
+
+### convert
+
+See {py:func}`converters.match()` about target version strings.
+
+```{eval-rst}
+.. argparse::
+    :module: convert
+    :func: make_parser
+    :prog: cl-file
+    :path: convert
+    :nodefault:
+```
+
+### versions
+
+Show all versions and exit.
+
+```{eval-rst}
+.. argparse::
+    :module: convert
+    :func: make_parser
+    :prog: cl-file
+    :path: versions
+    :nodefault:
+```
+
+### infer
+
+Show inferred version of file and exit.
+
+```{eval-rst}
+.. argparse::
+    :module: convert
+    :func: make_parser
+    :prog: cl-file
+    :path: infer
+    :nodefault:
+```
+
+## Converter API
+
+### converters
+
+```{eval-rst}
+.. autoclass:: model.Converter
+    :members:
+
+.. autoclass:: model.Document
+    :members:
+    :undoc-members:
+
+.. autoclass:: model.Annotation
+    :members:
+    :undoc-members:
+
+.. automodule:: converters
+    :members:
+```

--- a/Documentation/developer_guide/Annotations.md
+++ b/Documentation/developer_guide/Annotations.md
@@ -93,5 +93,7 @@ organization may change from version to version without notice.
 We mean it.
 
 ```{toctree}
+:maxdepth: 2
+Converter Script <AnnotationFileConverter>
 Version History <AnnotationFileFormat>
 ```

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -3,5 +3,6 @@ pygments
 sphinx
 sphinx-issues
 sphinx-notfound-page
-sphinx_rtd_theme
+sphinx-rtd-theme
+sphinx-argparse
 myst-parser

--- a/Scripts/convert/.gitignore
+++ b/Scripts/convert/.gitignore
@@ -1,0 +1,2 @@
+*.zip
+samples

--- a/Scripts/convert/.gitignore
+++ b/Scripts/convert/.gitignore
@@ -1,2 +1,5 @@
 *.zip
 samples
+idem
+update
+compare

--- a/Scripts/convert/compare.sh
+++ b/Scripts/convert/compare.sh
@@ -1,0 +1,16 @@
+# convert the same document to each of the supported versions; to allow comparing outputs
+# results are placed in ./compare/; the original document is copied to ./compare/base.json
+# each other output is named by the target version.
+
+f_in=samples/20170213_297662.003.15.json
+d_out=compare
+
+mkdir -p $d_out
+rm $d_out/*
+
+cp "$f_in" "$d_out/base.json"
+
+for version in $(python convert.py versions); do
+  result="${d_out}/${version}.json"
+  python convert.py convert "$f_in" "$result" -v? -t "$version" -i 2> /dev/null
+done

--- a/Scripts/convert/compare.sh
+++ b/Scripts/convert/compare.sh
@@ -12,5 +12,5 @@ cp "$f_in" "$d_out/base.json"
 
 for version in $(python convert.py versions); do
   result="${d_out}/${version}.json"
-  python convert.py convert "$f_in" "$result" -v? -t "$version" -i 2> /dev/null
+  python convert.py convert "$f_in" "$result" -v? -t "$version" 2> /dev/null
 done

--- a/Scripts/convert/convert.py
+++ b/Scripts/convert/convert.py
@@ -56,8 +56,7 @@ def infer(args):
 
     print(v)
 
-
-def main():
+def make_parser():
     parser = argparse.ArgumentParser(
         prog='convert',
         description=f'Convert Cell Locator annotation files between versions.',
@@ -111,6 +110,10 @@ def main():
     )
     sub_infer.set_defaults(func=infer)
 
+    return parser
+
+def main():
+    parser = make_parser()
     args = parser.parse_args()
     args.func(args)
 

--- a/Scripts/convert/convert.py
+++ b/Scripts/convert/convert.py
@@ -85,8 +85,8 @@ def make_parser():
         help='Target file version. Defaults to the latest version.',
     )
     sub_convert.add_argument(
-        '-i', '--indent', action='store_true',
-        help='Indent output JSON.',
+        '--no-indent', dest='indent', action='store_false', default=True,
+        help='Do not indent output JSON.',
     )
     sub_convert.set_defaults(func=convert)
 

--- a/Scripts/convert/convert.py
+++ b/Scripts/convert/convert.py
@@ -1,0 +1,119 @@
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import converters
+
+
+def convert(args):
+    # if src is '-', use stdin
+    if args.src != Path('-'):
+        with open(args.src) as src:
+            data = json.load(src)
+    else:
+        data = json.load(sys.stdin)
+
+    # if -v?, infer version
+    if args.version.lower() in ('?', 'infer'):
+        v, doc = converters.infer_normalize(data)
+        print(f'Inferred version {v!r}', file=sys.stderr)
+    else:
+        v, vc = converters.find_latest(args.version)
+        doc = vc.normalize(data)
+
+    # convert to target version
+    t, tc = converters.find_latest(args.target)
+    data = tc.specialize(doc)
+
+    # convert boolean indent to json.dump argument
+    indent = 2 if args.indent else None
+
+    # if dst is '-', use stdout
+    if args.dst != Path('-'):
+        args.dst.parent.mkdir(exist_ok=True, parents=True)
+        dst = args.dst.open('w')
+    else:
+        dst = sys.stdout
+
+    # dump output
+    json.dump(data, dst, indent=indent)
+
+
+def versions(args):
+    print('\n'.join(converters.match(args.target)))
+
+
+def infer(args):
+    # if src is '-', use stdin
+    if args.src != Path('-'):
+        with open(args.src) as src:
+            data = json.load(src)
+    else:
+        data = json.load(sys.stdin)
+
+    v, doc = converters.infer_normalize(data)
+
+    print(v)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog='convert',
+        description=f'Convert Cell Locator annotation files between versions.',
+    )
+
+    subs = parser.add_subparsers(dest='cmd', title='subcommands', required=True)
+
+    sub_convert = subs.add_parser(
+        'convert',
+        help='Convert between file versions.'
+    )
+    sub_convert.add_argument(
+        'src', type=Path,
+        help="Source JSON file. Use '-' to read from stdin.",
+    )
+    sub_convert.add_argument(
+        'dst', type=Path,
+        help="Destination JSON file. Use '-' to write to stdout.",
+    )
+    sub_convert.add_argument(
+        '-v', '--version', required=True,
+        help="Source file version. Use '-v?' to infer the version.",
+    )
+    sub_convert.add_argument(
+        '-t', '--target', default='',
+        help='Target file version. Defaults to the latest version.',
+    )
+    sub_convert.add_argument(
+        '-i', '--indent', action='store_true',
+        help='Indent output JSON.',
+    )
+    sub_convert.set_defaults(func=convert)
+
+    sub_versions = subs.add_parser(
+        'versions',
+        help='Show all versions and exit.',
+    )
+    sub_versions.add_argument(
+        'target', nargs='?', default='',
+        help='Show versions matching this target. If empty, show all versions.',
+    )
+    sub_versions.set_defaults(func=versions)
+
+    sub_infer = subs.add_parser(
+        'infer',
+        help='Show inferred version of file and exit.'
+    )
+    sub_infer.add_argument(
+        'src', type=Path,
+        help="Source JSON file. Use '-' to read from stdin.",
+    )
+    sub_infer.set_defaults(func=infer)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/Scripts/convert/converters.py
+++ b/Scripts/convert/converters.py
@@ -56,19 +56,21 @@ def infer_normalize(data: dict) -> Tuple[str, model.Document]:
 def match(target: str = '') -> Generator[str, None, None]:
     """Find the most-recent versions matching the target.
 
-    If target begins with 'd', then interpret the target as a date
+    Prefix with ``d`` to interpret as a date. Prefix with ``v``, or no prefix,
+    to interpret as a literal version.
 
-    If target begins with a 'v', or has no prefix, interpret the target as a version
-    directly.
+    ===================== ========= ========= ===========
+    Example Versions      ``v1.1``  ``v1.1.`` ``d2020.``
+    ===================== ========= ========= ===========
+    ``1.1.0+2019.02.01``  yes       yes       no
+    ``1.1.1+2020.02.07``  yes       yes       yes
+    ``1.2.0+2020.05.01``  no        no        yes
+    ``1.10.1+2021.03.01`` yes       no        no
+    ===================== ========= ========= ===========
 
-    Substring matching is used for all cases; if the version or date begins with the
-    target, then that version is matched. The most-recent matching version is chosen
-    as defined in version_order.
+    :param target: String describing target versions.
 
-    Since all versions would match the empty string, the most-recent available
-    version is returned if target is empty or would otherwise match all versions.
-
-    :returns: List of matching versions, in order of precedence (most-recent first)
+    :returns: Matching versions, in order of precedence (most-recent first)
     """
 
     key = target.lstrip('vd')
@@ -84,12 +86,10 @@ def match(target: str = '') -> Generator[str, None, None]:
 
 
 def find_latest(target: str = '') -> Tuple[str, model.Converter]:
-    """ Find the most-recent version and converter matching the target.
+    """Find the most-recent matching version and converter.
 
-    See match() for details on matching logic.
-
-    :returns: (version, converter) — The inferred version and the corresponding
-    converter.
+    :param target: The target version string. See match() for details on matching logic.
+    :return: The inferred version and the corresponding converter.
     """
 
     for version in match(target):

--- a/Scripts/convert/converters.py
+++ b/Scripts/convert/converters.py
@@ -1,0 +1,37 @@
+import importlib.util
+from pathlib import Path
+from typing import Dict, Tuple, Generator
+
+import model
+
+__all__ = [
+    'version_order', 'latest_version',
+]
+
+version_root = Path(__file__).parent.joinpath('versions')
+
+# most-recent versions first
+version_order = [
+    'v0.1.0+2020.09.18',
+    'v0.0.0+2020.08.26',
+    'v0.0.0+2020.04.16',
+    'v0.0.0+2019.01.26',
+]
+latest_version = version_order[0]
+
+
+def load_converter(version: str) -> model.Converter:
+    path = version_root.joinpath(version + '.py')
+    spec = importlib.util.spec_from_file_location(
+        'versions', str(path),
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    converter = module.Converter
+    return converter
+
+
+converters: Dict[str, model.Converter] = {
+    version: load_converter(version)
+    for version in version_order
+}

--- a/Scripts/convert/converters.py
+++ b/Scripts/convert/converters.py
@@ -5,7 +5,7 @@ from typing import Dict, Tuple, Generator
 import model
 
 __all__ = [
-    'version_order', 'latest_version',
+    'version_order', 'latest_version', 'infer_normalize', 'match', 'find_latest'
 ]
 
 version_root = Path(__file__).parent.joinpath('versions')
@@ -35,3 +35,64 @@ converters: Dict[str, model.Converter] = {
     version: load_converter(version)
     for version in version_order
 }
+
+
+def infer_normalize(data: dict) -> Tuple[str, model.Document]:
+    """Find the most-recent converter that can normalize the document.
+
+    :returns: (version, document) — The inferred version and the normalized document.
+    """
+
+    for version in match():
+        try:
+            converter = converters[version]
+            doc = converter.normalize(data)
+            return version, doc
+        except (KeyError, IndexError, AttributeError):
+            continue
+    raise ValueError('No converter can normalize the data')
+
+
+def match(target: str = '') -> Generator[str, None, None]:
+    """Find the most-recent versions matching the target.
+
+    If target begins with 'd', then interpret the target as a date
+
+    If target begins with a 'v', or has no prefix, interpret the target as a version
+    directly.
+
+    Substring matching is used for all cases; if the version or date begins with the
+    target, then that version is matched. The most-recent matching version is chosen
+    as defined in version_order.
+
+    Since all versions would match the empty string, the most-recent available
+    version is returned if target is empty or would otherwise match all versions.
+
+    :returns: List of matching versions, in order of precedence (most-recent first)
+    """
+
+    key = target.lstrip('vd')
+
+    if target.startswith('d'):
+        key = f'+{key}'
+    else:
+        key = f'v{key}'
+
+    for version in version_order:
+        if key in version:
+            yield version
+
+
+def find_latest(target: str = '') -> Tuple[str, model.Converter]:
+    """ Find the most-recent version and converter matching the target.
+
+    See match() for details on matching logic.
+
+    :returns: (version, converter) — The inferred version and the corresponding
+    converter.
+    """
+
+    for version in match(target):
+        return version, converters[version]
+
+    raise ValueError(f'no version matches {target!r}')

--- a/Scripts/convert/idem.sh
+++ b/Scripts/convert/idem.sh
@@ -1,0 +1,18 @@
+# idempotency test. convert each file in ./samples/ to its own version
+# ideally this would leave each file unchanged, however some changes will occur
+# results are placed in ./idem/; then meld https://meldmerge.org/ is invoked to show
+# a diff of all the changes
+
+d_in=samples
+d_out=idem
+
+mkdir -p $d_out
+rm $d_out/*
+
+for sample in $d_in/*.json; do
+  result="${d_out}/${sample##*/}"
+  version=$(python convert.py infer "$sample")
+  python convert.py convert "$sample" "$result" -v "$version" -t "$version" -i
+done
+
+meld "$d_in" "$d_out" 2> /dev/null

--- a/Scripts/convert/idem.sh
+++ b/Scripts/convert/idem.sh
@@ -12,7 +12,7 @@ rm $d_out/*
 for sample in $d_in/*.json; do
   result="${d_out}/${sample##*/}"
   version=$(python convert.py infer "$sample")
-  python convert.py convert "$sample" "$result" -v "$version" -t "$version" -i
+  python convert.py convert "$sample" "$result" -v "$version" -t "$version"
 done
 
 meld "$d_in" "$d_out" 2> /dev/null

--- a/Scripts/convert/model.py
+++ b/Scripts/convert/model.py
@@ -13,15 +13,21 @@ Matrix4f = Tuple[float, float, float, float,
 
 @dataclass
 class Annotation:
+    """Store minimal information about a single annotation """
+
     name: str = ''
 
     markup_type: str = 'ClosedCurve'
     representation_type: str = 'spline'
+    """Type for a closed curve annotation; ex 'spline' or 'polyline'."""
     thickness: float = 50
+    """Thickness of the annotation model"""
 
     # coordinate system should always be LPS in these dataclasses
     coordinate_system: str = 'LPS'
+    """Should always be LPS here; older versions of Slicer use RAS."""
     coordinate_units: str = 'um'
+    """Should be um for CCF atlas, mm for MNI atlas."""
 
     orientation: Matrix4f = (
         1.0, 0.0, 0.0, 0.25,
@@ -29,19 +35,33 @@ class Annotation:
         0.0, 1.0, 0.0, 22.25,
         0.0, 0.0, 0.0, 1.0,
     )
+    """A transformation matrix storing the orientation of the slicing plane."""
 
     points: List[Vector3f] = dataclasses.field(default_factory=list)
+    """Control point positions for the annotation markup."""
 
 
 @dataclass
 class Document:
     annotations: List[Annotation] = dataclasses.field(default_factory=list)
+
     current_id: int = 0
+    """Index of the currently-selected annotation."""
+
     reference_view: str = 'Coronal'
+    """Initial reference view. Ex. 'Coronal', 'Axial', or 'Sagittal'."""
     ontology: str = 'Structure'
+    """Initial atlas ontology. Ex. 'Structure', 'Layer', or 'None'"""
+
     stepSize: float = 0.5
+    """Distance in :py:attr:`Annotation.coordinate_units` to move slice plane in 
+    Explore mode.
+    """
+
     camera_position: Vector3f = (51.6226, -631.3969, -605.9925)
+    """Initial camera position."""
     camera_view_up: Vector3f = (-.5686, -.6042, .5582)
+    """Initial camera 'up' vector."""
 
 
 class Converter(abc.ABC):
@@ -52,6 +72,18 @@ class Converter(abc.ABC):
 
     "Normalized" -- a dataclass representation common to all versions of
     cell locator. An intermediate representation during the conversion process.
+
+    For example, the flow to update a file to a different version would be:
+
+    >>> doc = old_converter.normalize(data)
+    >>> new_data = new_converter.specialize(doc)
+
+    It is also easier to perform manipulations on a ``Document``. For example:
+
+    >>> doc = converter.normalize(data)
+    >>> for annotation in doc.annotations:
+    ...     annotation.name = annotation.name.lower()
+    >>> data = converter.specialize(data)
     """
 
     @classmethod
@@ -63,5 +95,7 @@ class Converter(abc.ABC):
     @classmethod
     @abc.abstractmethod
     def specialize(cls, doc: Document):
-        """Convert a normalized Document to a specialized dict."""
+        """Convert a normalized Document to a specialized dict; specific to this
+        version.
+        """
         pass

--- a/Scripts/convert/model.py
+++ b/Scripts/convert/model.py
@@ -1,0 +1,67 @@
+import abc
+import dataclasses
+from dataclasses import dataclass
+
+from typing import List, Tuple
+
+Vector3f = Tuple[float, float, float]
+Matrix4f = Tuple[float, float, float, float,
+                 float, float, float, float,
+                 float, float, float, float,
+                 float, float, float, float]
+
+
+@dataclass
+class Annotation:
+    name: str = ''
+
+    markup_type: str = 'ClosedCurve'
+    representation_type: str = 'spline'
+    thickness: float = 50
+
+    # coordinate system should always be LPS in these dataclasses
+    coordinate_system: str = 'LPS'
+    coordinate_units: str = 'um'
+
+    orientation: Matrix4f = (
+        1.0, 0.0, 0.0, 0.25,
+        0.0, 0.0, 1.0, -17.5,
+        0.0, 1.0, 0.0, 22.25,
+        0.0, 0.0, 0.0, 1.0,
+    )
+
+    points: List[Vector3f] = dataclasses.field(default_factory=list)
+
+
+@dataclass
+class Document:
+    annotations: List[Annotation] = dataclasses.field(default_factory=list)
+    current_id: int = 0
+    reference_view: str = 'Coronal'
+    ontology: str = 'Structure'
+    stepSize: float = 0.5
+    camera_position: Vector3f = (51.6226, -631.3969, -605.9925)
+    camera_view_up: Vector3f = (-.5686, -.6042, .5582)
+
+
+class Converter(abc.ABC):
+    """ Utility to aid in conversion of Cell Locator files.
+
+    "Specialized" -- a dict representation of a version-specific
+    JSON. That representation may only work in one version of Cell Locator.
+
+    "Normalized" -- a dataclass representation common to all versions of
+    cell locator. An intermediate representation during the conversion process.
+    """
+
+    @classmethod
+    @abc.abstractmethod
+    def normalize(cls, data: dict):
+        """Convert a specialized dict to a normalized Document"""
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def specialize(cls, doc: Document):
+        """Convert a normalized Document to a specialized dict."""
+        pass

--- a/Scripts/convert/update.sh
+++ b/Scripts/convert/update.sh
@@ -8,5 +8,5 @@ mkdir -p $d_out
 
 for sample in $d_in/*.json; do
   result="${d_out}/${sample##*/}"
-  python convert.py convert "$sample" "$result" -v? -i 2> /dev/null
+  python convert.py convert "$sample" "$result" -v? 2> /dev/null
 done

--- a/Scripts/convert/update.sh
+++ b/Scripts/convert/update.sh
@@ -1,0 +1,12 @@
+# update all files in ./samples/ to the latest supported version.
+# results are placed in ./update/ with the same filenames
+
+d_in=samples
+d_out=update
+
+mkdir -p $d_out
+
+for sample in $d_in/*.json; do
+  result="${d_out}/${sample##*/}"
+  python convert.py convert "$sample" "$result" -v? -i 2> /dev/null
+done

--- a/Scripts/convert/version-changlist.md
+++ b/Scripts/convert/version-changlist.md
@@ -1,0 +1,121 @@
+# Base
+
+```diff
++ Locked
++ MarkupLabelFormat
++ Markups []
++ Markups_Count
++ TextList [null]
++ TextList_Count 0
+```
+
+
+# 2019-01-26 -> 2020-04-16
+
+2020-04-16, 2020-04-30, and 2020-08-26 all use the same format.
+
+```diff
++ DefaultCameraPosition
++ DefaultCameraViewUp
++ DefaultOntology
++ DefaultReferenceView
++ DefaultRepresentationType
++ DefaultSplineOrientation
++ DefaultStepSize
++ DefaultThickness
+```
+
+# 2020-04-16 -> 2020-08-26
+
+Major Change
+
+```diff
+! DefaultCameraPosition      -> cameraPosition
+! DefaultCameraViewUp        -> cameraViewUp
+! DefaultOntology            -> ontology
+! DefaultReferenceView       -> referenceView
+! DefaultStepSize            -> stepSize 
+
+- DefaultRepresentationType
+- DefaultSplineOrientation
+- DefaultThickness
+
+- Locked
+! MarkupLabelFormat -> markups[].markup.labelFormat 
+- Markups_Count
+- TextList
+- TextList_Count
+
+! Markups[] (each element):
+!     OrientationWXYZ -> orientation
+!     RepresentationType -> representationType
+!     Thickness -> thickness
+
++     markup
++         type
++         coordinateSystem
++         locked
++         labelFormat
++         controlPoints []
++             id
++             label
++             description
++             associatedNodeID
++             position []
++             orientation []
++             selected
++             locked
++             visibility
++             positionStatus
++         display
++             <displaynode>
+            
+-     AssociatedNodeID
+-     CameraPosition
+-     CameraViewUp
+-     Closed
+-     Description
+-     ID
+-     Label
+!     Locked -> markup.locked
+-     Ontology
+!     Points[][] -> markup.controlPoints[].position[]
+-     Poinst_Count
+-     ReferenceView
+-     Selected
+-     StepSize
+-     Visibility
+```
+
+# 2020-08-26 -> 2020-09-18
+
+```diff
+! markups[]
++     name
+!     markup
+-         locked
+-         labelFormat
+-         display
+!         controlPoints
+-             associatedNodeID
+-             description
+-             label
+-             locked
+-             positionStatus
+-             selected
+-             visibility
+```
+
+# 2020-09-18 -> 2021-06-08
+
+```diff
++ version
+! markups[]
++     coordinateUnits
++     measurements []
++         name
++         enabled
++         printFormat
++         units?
+```
+

--- a/Scripts/convert/versions/v0.0.0+2019.01.26.py
+++ b/Scripts/convert/versions/v0.0.0+2019.01.26.py
@@ -1,0 +1,84 @@
+import model
+
+class Converter(model.Converter):
+    @classmethod
+    def normalize(cls, data: dict):
+        doc = model.Document()
+
+        # this format only supports one markup
+        doc.current_id = 0
+        for i, dmark in enumerate(data['Markups']):
+            if dmark['Selected']:
+                doc.current_id = i
+
+                doc.reference_view = dmark['ReferenceView']
+                doc.ontology = dmark['Ontology']
+                doc.stepSize = dmark['StepSize']
+                doc.camera_position = tuple(dmark['CameraPosition'])
+                doc.camera_view_up = tuple(dmark['CameraViewUp'])
+
+                break
+
+        for i, dmark in enumerate(data['Markups']):
+            ann = model.Annotation()
+            ann.name = dmark['Label']
+            ann.markup_type = 'ClosedCurve'
+
+            ann.coordinate_system = 'LPS'
+            ann.points = [
+                (-p['x'], -p['y'], p['z'])  # RAS → LPS conversion
+                for p in dmark['Points']
+            ]
+
+            ann.thickness = dmark['Thickness']
+            ann.orientation = dmark['SplineOrientation']
+            ann.representation_type = dmark['RepresentationType']
+
+            doc.annotations.append(ann)
+
+        return doc
+
+    @classmethod
+    def specialize(cls, doc: model.Document):
+        data = dict()
+        data['version'] = '0.0.0+2019.01.26'
+
+        data["Locked"] = 0
+        data["MarkupLabelFormat"] = "%N-%d"
+
+        data['Markups'] = [
+            {
+                'AssociatedNodeID': f'vtkMRMLModelNode{i}',
+                'CameraPosition': doc.camera_position,
+                'CameraViewUp': doc.camera_view_up,
+                'Closed': 1,
+                'Description': '',
+                'ID': f'vtkMRMLMarkupsSplinesNode_{i}',
+                'Label': ann.name,
+                'Locked': 1,
+                'Ontology': doc.ontology,
+                'OrientationWXYZ': [0.0, 0.0, 0.0, 1.0],
+                'Points': [
+                    {'x': -x, 'y': -y, 'z': z}
+                    for x, y, z in ann.points
+                ],
+                'Points_Count': str(len(ann.points)),
+                'ReferenceView': doc.reference_view,
+                'RepresentationType': ann.representation_type,
+                'Selected': 0,  # set later
+                'SplineOrientation': ann.orientation,
+                'StepSize': doc.stepSize,
+                'Thickness': ann.thickness,
+                'Visibility': 1
+            }
+            for i, ann in enumerate(doc.annotations)
+        ]
+
+        data['Markups'][doc.current_id]['Selected'] = 1
+        data['Markups'][doc.current_id]['Locked'] = 0
+
+        data['Markups_Count'] = len(doc.annotations)
+        data['TextList'] = [None]
+        data['TextList_Count'] = 0
+
+        return data

--- a/Scripts/convert/versions/v0.0.0+2020.04.16.py
+++ b/Scripts/convert/versions/v0.0.0+2020.04.16.py
@@ -1,0 +1,106 @@
+import model
+
+
+class Converter(model.Converter):
+    @classmethod
+    def normalize(cls, data: dict):
+        doc = model.Document()
+
+        # expect these to be present, even though we don't actually need them.
+        # conversion will still fail so that inference works correctly.
+        _ = data["DefaultCameraPosition"]
+        _ = data["DefaultCameraViewUp"]
+        _ = data["DefaultOntology"]
+        _ = data["DefaultReferenceView"]
+        _ = data["DefaultRepresentationType"]
+        _ = data["DefaultSplineOrientation"]
+        _ = data["DefaultStepSize"]
+        _ = data["DefaultThickness"]
+
+        # set document-wide values based on the currently selected markup.
+        doc.current_id = 0
+        for i, dmark in enumerate(data['Markups']):
+            if dmark['Selected']:
+                doc.current_id = i
+
+                doc.reference_view = dmark['ReferenceView']
+                doc.ontology = dmark['Ontology']
+                doc.stepSize = dmark['StepSize']
+                doc.camera_position = tuple(dmark['CameraPosition'])
+                doc.camera_view_up = tuple(dmark['CameraViewUp'])
+
+                break
+
+        # copy markup-specific values
+        for i, dmark in enumerate(data['Markups']):
+            ann = model.Annotation()
+            ann.name = dmark['Label']
+            ann.markup_type = 'ClosedCurve'
+
+            ann.coordinate_system = 'LPS'
+            ann.points = [
+                (-p['x'], -p['y'], p['z'])  # RAS → LPS conversion
+                for p in dmark['Points']
+            ]
+
+            ann.thickness = dmark['Thickness']
+            ann.orientation = dmark['SplineOrientation']
+            ann.representation_type = dmark['RepresentationType']
+
+            doc.annotations.append(ann)
+
+        return doc
+
+    @classmethod
+    def specialize(cls, doc: model.Document):
+        data = dict()
+        data['version'] = '0.0.0+2020.04.16'
+
+        data["DefaultCameraPosition"] = doc.camera_position
+        data["DefaultCameraViewUp"] = doc.camera_view_up
+        data["DefaultOntology"] = doc.ontology
+        data["DefaultReferenceView"] = doc.reference_view
+        data["DefaultRepresentationType"] = "polyline"
+
+        current_ann = doc.annotations[doc.current_id]
+        data["DefaultSplineOrientation"] = current_ann.orientation
+        data["DefaultStepSize"] = doc.stepSize
+        data["DefaultThickness"] = current_ann.thickness
+        data["Locked"] = 0
+        data["MarkupLabelFormat"] = "%N-%d"
+
+        data['Markups'] = [
+            {
+                'AssociatedNodeID': f'vtkMRMLModelNode{i}',
+                'CameraPosition': doc.camera_position,
+                'CameraViewUp': doc.camera_view_up,
+                'Closed': 1,
+                'Description': '',
+                'ID': f'vtkMRMLMarkupsSplinesNode_{i}',
+                'Label': ann.name,
+                'Locked': 1,
+                'Ontology': doc.ontology,
+                'OrientationWXYZ': [0.0, 0.0, 0.0, 1.0],
+                'Points': [
+                    {'x': -x, 'y': -y, 'z': z}
+                    for x, y, z in ann.points
+                ],
+                'Points_Count': str(len(ann.points)),
+                'ReferenceView': doc.reference_view,
+                'RepresentationType': ann.representation_type,
+                'Selected': 0,  # set later
+                'SplineOrientation': ann.orientation,
+                'StepSize': doc.stepSize,
+                'Thickness': ann.thickness,
+                'Visibility': 1
+            }
+            for i, ann in enumerate(doc.annotations)
+        ]
+
+        data['Markups'][doc.current_id]['Selected'] = 1
+
+        data['Markups_Count'] = len(doc.annotations)
+        data['TextList'] = [None]
+        data['TextList_Count'] = 0
+
+        return data

--- a/Scripts/convert/versions/v0.0.0+2020.08.26.py
+++ b/Scripts/convert/versions/v0.0.0+2020.08.26.py
@@ -1,0 +1,103 @@
+import model
+
+
+class Converter(model.Converter):
+    @classmethod
+    def normalize(cls, data: dict):
+        doc = model.Document()
+        doc.current_id = data['currentId']
+        doc.reference_view = data['referenceView']
+        doc.ontology = data['ontology']
+        doc.stepSize = data['stepSize']
+        doc.camera_position = tuple(data['cameraPosition'])
+        doc.camera_view_up = tuple(data['cameraViewUp'])
+
+        for i, dann in enumerate(data['markups'], start=1):
+            dmark = dann['markup']
+
+            ann = model.Annotation()
+            ann.name = f'Annotation {i}'
+            ann.orientation = dann['orientation']
+            ann.representation_type = dann['representationType']
+            ann.thickness = dann['thickness']
+
+            ann.markup_type = dmark['type']
+            ann.coordinate_system = dmark['coordinateSystem']
+            if 'coordinateUnits' in dmark:
+                ann.coordinate_units = dmark['coordinateUnits']
+
+            for point in dmark['controlPoints']:
+                ann.points.append(tuple(point['position']))
+
+            doc.annotations.append(ann)
+
+        return doc
+
+    @classmethod
+    def specialize(cls, doc: model.Document):
+        data = dict()
+        data['version'] = '0.0.0+2020.08.26'
+        data['markups'] = [
+            {
+                'markup': {
+                    'type': ann.markup_type,
+                    'coordinateSystem': ann.coordinate_system,
+                    'locked': False,
+                    'labelFormat': '%N-%d',
+                    'controlPoints': [
+                        {
+                            'id': str(i),
+                            'label': f'MarkupsClosedCurve-{i}',
+                            'description': '',
+                            'associatedNodeID': 'vtkMRMLScalarVolumeNode1',
+                            'position': pt,
+                            'orientation': [-1.0, -0.0, -0.0,
+                                            -0.0, -1.0, -0.0,
+                                            +0.0, +0.0, +1.0],
+                            'selected': False,
+                            'locked': False,
+                            'visibility': True,
+                            'positionStatus': 'defined',
+                        }
+                        for i, pt in enumerate(ann.points, start=1)
+                    ],
+                    'display': {
+                        "visibility": True,
+                        "opacity": 1.0,
+                        "color": (0.4, 1.0, 1.0),
+                        "selectedColor": (1.0, 0.5, 0.5),
+                        "propertiesLabelVisibility": True,
+                        "pointLabelsVisibility": False,
+                        "textScale": 3.0,
+                        "glyphType": "Sphere3D",
+                        "glyphScale": 1.0,
+                        "glyphSize": 5.0,
+                        "useGlyphScale": True,
+                        "sliceProjection": False,
+                        "sliceProjectionUseFiducialColor": True,
+                        "sliceProjectionOutlinedBehindSlicePlane": False,
+                        "sliceProjectionColor": (1.0, 1.0, 1.0),
+                        "sliceProjectionOpacity": 0.6,
+                        "lineThickness": 0.2,
+                        "lineColorFadingStart": 1.0,
+                        "lineColorFadingEnd": 10.0,
+                        "lineColorFadingSaturation": 1.0,
+                        "lineColorFadingHueOffset": 0.0,
+                        "handlesInteractive": False,
+                        "snapMode": "toVisibleSurface"
+                    }
+                },
+                'orientation': ann.orientation,
+                'representationType': ann.representation_type,
+                'thickness': ann.thickness
+            }
+            for ann in doc.annotations
+        ]
+        data['currentId'] = doc.current_id
+        data['referenceView'] = doc.reference_view
+        data['ontology'] = doc.ontology
+        data['stepSize'] = doc.stepSize
+        data['cameraPosition'] = doc.camera_position
+        data['cameraViewUp'] = doc.camera_view_up
+
+        return data

--- a/Scripts/convert/versions/v0.1.0+2020.09.18.py
+++ b/Scripts/convert/versions/v0.1.0+2020.09.18.py
@@ -1,0 +1,71 @@
+import model
+
+
+class Converter(model.Converter):
+    @classmethod
+    def normalize(cls, data: dict):
+        doc = model.Document()
+        doc.current_id = data['currentId']
+        doc.reference_view = data['referenceView']
+        doc.ontology = data['ontology']
+        doc.stepSize = data['stepSize']
+        doc.camera_position = tuple(data['cameraPosition'])
+        doc.camera_view_up = tuple(data['cameraViewUp'])
+
+        for dann in data['markups']:
+            dmark = dann['markup']
+
+            ann = model.Annotation()
+            ann.name = dann['name']
+            ann.orientation = dann['orientation']
+            ann.representation_type = dann['representationType']
+            ann.thickness = dann['thickness']
+
+            ann.markup_type = dmark['type']
+            ann.coordinate_system = dmark['coordinateSystem']
+            if 'coordinateUnits' in dmark:
+                ann.coordinate_units = dmark['coordinateUnits']
+
+            for point in dmark['controlPoints']:
+                ann.points.append(tuple(point['position']))
+
+            doc.annotations.append(ann)
+
+        return doc
+
+    @classmethod
+    def specialize(cls, doc: model.Document):
+        data = dict()
+        data['version'] = '0.1.0+2020.09.18'
+        data['markups'] = [
+            {
+                'markup': {
+                    'type': ann.markup_type,
+                    'coordinateSystem': ann.coordinate_system,
+                    'coordinateUnits': ann.coordinate_units,
+                    'controlPoints': [
+                        {
+                            'id': str(i),
+                            'position': pt,
+                            'orientation': [-1.0, -0.0, -0.0,
+                                            -0.0, -1.0, -0.0,
+                                            +0.0, +0.0, +1.0]
+                        }
+                        for i, pt in enumerate(ann.points, start=1)
+                    ],
+                },
+                'name': ann.name,
+                'orientation': ann.orientation,
+                'representationType': ann.representation_type,
+                'thickness': ann.thickness
+            }
+            for ann in doc.annotations
+        ]
+        data['currentId'] = doc.current_id
+        data['referenceView'] = doc.reference_view
+        data['ontology'] = doc.ontology
+        data['stepSize'] = doc.stepSize
+        data['cameraPosition'] = doc.camera_position
+        data['cameraViewUp'] = doc.camera_view_up
+
+        return data


### PR DESCRIPTION
This adds a conversion tool `convert.py` and some test bash scripts to serve as example usage: `idem.sh`, `update.sh`, and `compare.sh`

I've tested this against the files listed in https://github.com/BICCN/cell-locator/pull/160#issuecomment-702512235, https://github.com/BICCN/cell-locator/pull/160#issuecomment-858728096, and https://github.com/BICCN/cell-locator/issues/158#issue-709339736

`idem.sh` converts each file to its own version. Ideally, this would leave the file unchanged, however some differences are inevitable introduced as there is some information loss. Here are the changes that occur in each version.

All converters add `.version` and sometimes cause negligible floating-point errors.

- 0.0.0+2019.01.26
    - adds `.version`
    - resets numbering of `.Markups[].ID`, starting at 0.
    - resets numbering of `.Markups[].AssociatedNodeID`, starting at 0.

- 0.0.0+2020.04.16
    - adds `.version`
    - resets numbering of `.Markups[].ID`, starting at 0.
    - resets numbering of `.Markups[].AssociatedNodeID`, starting at 0.

- 0.0.0+2020.08.26
    - adds `.version`
    - sets `.markups[].markup.controlPoints[].selected` to False
    - reduces precision of `.markup[].markup.display.selectedColor`

- 0.1.0+2020.09.18
    - adds `.version`
    - removes `.markups[].markup.measurements`
    - adds `.markups[].markup.coordinateUnits`

You can see all the exact changes on the mentioned files here: https://github.com/allemangD/cell-locator/commit/7bddbed0386005d5318ea6c92be4a239addae31c

---

All the scripts and classes are documented with docstrings and argparse help text. I've also added some technical documentation and autodocs to the readthedocs; ~~I'd like to publish this branch on readthedocs as a preview but I'm struggling to get the interface to recognize that this branch exists.~~

The technical documentation and autodocs can be found at: https://cell-locator.readthedocs.io/en/conversion-script/developer_guide/AnnotationFileConverter.html

Here is how the conversion tool help text looks:

```
$ python convert.py convert -h
usage: convert convert [-h] -v VERSION [-t TARGET] [--no-indent] src dst

positional arguments:
  src                   Source JSON file. Use '-' to read from stdin.
  dst                   Destination JSON file. Use '-' to write to stdout.

optional arguments:
  -h, --help            show this help message and exit
  -v VERSION, --version VERSION
                        Source file version. Use '-v?' to infer the version.
  -t TARGET, --target TARGET
                        Target file version. Defaults to the latest version.
  --no-indent           Do not indent output JSON.
```

----

I am not sure the best way to organize the converters. I want to satisfy these criteria

- each converter should be in its own file
- each filename should show the converter version

The only reasonable way I've figured to do this is to name the files using the semantic version string for the corresponding converter. However, that means the files are no longer valid Python module names. `.` and `+` are forbidden characters, and the name must not start with a digit; semantic versions require all of these.

After some discussion with @jcfr, we decided that this way makes the most sense. Although it is a gross violation of general python style advice, I think the readability improvement is worth it.

Supersedes https://github.com/BICCN/cell-locator/pull/160 