### PR TITLE
Remove Measurements from JSON output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,11 @@
 
 Features:
 
+- Created script to convert between Cell Locator file formats. [#181](https://github.com/BICCN/cell-locator/pull/181), [#182](https://github.com/BICCN/cell-locator/pull/182)
+
 Fixes:
+
+- Fixed new `"measurements"` key being incorrectly included in serialization. [#182](https://github.com/BICCN/cell-locator/issues/182)
 
 Documentation:
 
@@ -12,6 +16,7 @@ Documentation:
 - Provide documentation and example of how to create new Annotation types.
 - Document the mock LIMS server and LIMS API.
 - Switch from recommonmark to [MyST](https://myst-parser.readthedocs.io/en/latest/); so that reStructuredText may be avoided entirely. See [Slicer#5662](https://github.com/Slicer/Slicer/pull/5662).
+- File Format Version bumped to `0.1.1+2021-06-11` [#183](https://github.com/BICCN/cell-locator/pull/183)
 
 ## Cell Locator 0.1.0 2021-05-21
 

--- a/Documentation/developer_guide/AnnotationFileConverter.md
+++ b/Documentation/developer_guide/AnnotationFileConverter.md
@@ -53,6 +53,8 @@ Show inferred version of file and exit.
 .. autoclass:: model.Converter
     :members:
 
+.. autodecorator:: model.versioned
+
 .. autoclass:: model.Document
     :members:
     :undoc-members:

--- a/Documentation/developer_guide/AnnotationFileFormat.md
+++ b/Documentation/developer_guide/AnnotationFileFormat.md
@@ -10,6 +10,156 @@ We mean it.
 
 ## Versions
 
+## 0.1.1 (2021-06-11)
+
+Removed the `"measurements"` key from markups.
+
+```json
+{
+    "version": "0.1.1+2021.06.11",
+    "markups": [
+        {
+            "markup": {
+                "type": "ClosedCurve",
+                "coordinateSystem": "LPS",
+                "controlPoints": [
+                    {
+                        "id": "1",
+                        "position": [
+                            -7725.476777936878,
+                            5071.924649397559,
+                            -2858.6838622146615
+                        ],
+                        "orientation": [
+                            -1.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            -1.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            1.0
+                        ]
+                    },
+                    {
+                        "id": "2",
+                        "position": [
+                            -8785.61316343005,
+                            5514.035987881592,
+                            -4251.158410257692
+                        ],
+                        "orientation": [
+                            -1.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            -1.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            1.0
+                        ]
+                    },
+                    {
+                        "id": "3",
+                        "position": [
+                            -7732.355384361564,
+                            5984.77667260136,
+                            -4339.759187924226
+                        ],
+                        "orientation": [
+                            -1.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            -1.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            1.0
+                        ]
+                    },
+                    {
+                        "id": "4",
+                        "position": [
+                            -6980.525470132225,
+                            5682.868336976309,
+                            -3371.0529631232225
+                        ],
+                        "orientation": [
+                            -1.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            -1.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            1.0
+                        ]
+                    },
+                    {
+                        "id": "5",
+                        "position": [
+                            -6735.759199784232,
+                            5461.593738502808,
+                            -2856.7326570107934
+                        ],
+                        "orientation": [
+                            -1.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            -1.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            1.0
+                        ]
+                    }
+                ]
+            },
+            "name": "Annotation",
+            "orientation": [
+                0.9423723483536421,
+                -0.10260749019479301,
+                -0.3184431817677528,
+                5686.499999999999,
+                0.32619099971630533,
+                0.49341126738558755,
+                0.8063155417831328,
+                -6574.999999999999,
+                -0.07438943985890348,
+                0.863722770437872,
+                -0.49844677455532305,
+                -3987.4999999999995,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+            ],
+            "representationType": "spline",
+            "thickness": 50
+        }
+    ],
+    "currentId": 0,
+    "referenceView": "Coronal",
+    "ontology": "Structure",
+    "stepSize": 24.999999999999996,
+    "cameraPosition": [
+        5864.945206940424,
+        -50233.77100882346,
+        -4015.7997990419617
+    ],
+    "cameraViewUp": [
+        0.0,
+        0.0,
+        1.0
+    ]
+}
+```
+
 ## 0.1.0 (2020-09-18), Unversioned (2020-09-18)
 
 Annotation files generated with Cell-Locator [0.1.0-2020-09-18](https://github.com/BICCN/cell-locator/releases/tag/0.1.0-2020-09-18) do not include the `version` key.
@@ -21,6 +171,7 @@ Annotation files generated with Cell-Locator [0.1.0-2020-09-18](https://github.c
             "markup": {
                 "type": "ClosedCurve",
                 "coordinateSystem": "LPS",
+                "measurements": [],
                 "controlPoints": [
                     {
                         "id": "1",

--- a/Documentation/developer_guide/Annotations.md
+++ b/Documentation/developer_guide/Annotations.md
@@ -97,3 +97,13 @@ We mean it.
 Converter Script <AnnotationFileConverter>
 Version History <AnnotationFileFormat>
 ```
+
+### Modifying the File Format
+
+When a change is made to the file format (e.g. a new type of Annotation is added), be sure to update the conversion script and documentation
+
+- Follow [semantic versioning](https://semver.org/) to increment `AnnotationManager.FORMAT_VERSION` in `Home.py`. Use the date of the release as the build metadata.
+- Update the conversion script
+  - Create a converter in `Scripts/convert/versions`. It's easiest to copy the most-recent converter and modify the `specialize` and `normalize` methods accordingly. See the [Converter API](./AnnotationFileConverter.html#converter-api)
+  - Update `version_order` in `Scripts/convert/converters.py`. Add the new version number at the top of the list; this way `latest_version` will point to the new converter.
+- Update the version history at `Documentation/developer_guide/AnnotationFileFormat.md`.

--- a/Modules/Scripted/Home/Home.py
+++ b/Modules/Scripted/Home/Home.py
@@ -57,6 +57,10 @@ def listToMat(lst: list) -> vtk.vtkMatrix4x4:
   return mat
 
 
+def dict_whitelist(data, keys):
+  return {key: data[key] for key in keys}
+
+
 class Annotation(VTKObservationMixin):
   """Manage serialization of a single annotation."""
 
@@ -118,18 +122,24 @@ class Annotation(VTKObservationMixin):
         markup = json.load(f)
         markup = markup['markups'][0]
 
-        # Remove optional keys
-        del markup['display']
-        del markup['locked']
-        del markup['labelFormat']
-        for controlPoint in markup['controlPoints']:
-          del controlPoint['associatedNodeID']
-          del controlPoint['description']
-          del controlPoint['label']
-          del controlPoint['locked']
-          del controlPoint['positionStatus']
-          del controlPoint['selected']
-          del controlPoint['visibility']
+        markup_whitelist = [
+          'type',
+          'coordinateSystem',
+          'controlPoints',
+        ]
+
+        control_whitelist = [
+          'id',
+          'position',
+          'orientation',
+        ]
+
+        markup = dict_whitelist(markup, markup_whitelist)
+
+        markup['controlPoints'] = [
+          dict_whitelist(control, control_whitelist)
+          for control in markup['controlPoints']
+        ]
 
     return {
       'markup': markup,

--- a/Modules/Scripted/Home/Home.py
+++ b/Modules/Scripted/Home/Home.py
@@ -273,7 +273,7 @@ class ClosedCurveAnnotation(Annotation):
 class AnnotationManager:
   """Manage serialization and bookkeeping for a collection of annotations."""
 
-  FORMAT_VERSION = '0.1.0+2020.09.18'
+  FORMAT_VERSION = '0.1.1+2021.06.11'
 
   DefaultReferenceView = 'Coronal'
   DefaultOntology = 'Structure'

--- a/Scripts/convert/convert.py
+++ b/Scripts/convert/convert.py
@@ -56,6 +56,7 @@ def infer(args):
 
     print(v)
 
+
 def make_parser():
     parser = argparse.ArgumentParser(
         prog='convert',
@@ -111,6 +112,7 @@ def make_parser():
     sub_infer.set_defaults(func=infer)
 
     return parser
+
 
 def main():
     parser = make_parser()

--- a/Scripts/convert/converters.py
+++ b/Scripts/convert/converters.py
@@ -12,6 +12,7 @@ version_root = Path(__file__).parent.joinpath('versions')
 
 # most-recent versions first
 version_order = [
+    'v0.1.1+2021.06.11',
     'v0.1.0+2020.09.18',
     'v0.0.0+2020.08.26',
     'v0.0.0+2020.04.16',

--- a/Scripts/convert/converters.py
+++ b/Scripts/convert/converters.py
@@ -1,4 +1,5 @@
 import importlib.util
+import sys
 from pathlib import Path
 from typing import Dict, Tuple, Generator
 
@@ -24,9 +25,10 @@ latest_version = version_order[0]
 def load_converter(version: str) -> model.Converter:
     path = version_root.joinpath(version + '.py')
     spec = importlib.util.spec_from_file_location(
-        'versions', str(path),
+        version, path,
     )
     module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     converter = module.Converter
     return converter

--- a/Scripts/convert/model.py
+++ b/Scripts/convert/model.py
@@ -1,8 +1,11 @@
 import abc
 import dataclasses
+import inspect
 from dataclasses import dataclass
-
+from pathlib import Path
 from typing import List, Tuple
+
+__all__ = ['Annotation', 'Document', 'Converter']
 
 Vector3f = Tuple[float, float, float]
 Matrix4f = Tuple[float, float, float, float,
@@ -64,6 +67,11 @@ class Document:
     """Initial camera 'up' vector."""
 
 
+class classproperty(property):
+    def __get__(self, object, owner):
+        return self.fget(owner)
+
+
 class Converter(abc.ABC):
     """ Utility to aid in conversion of Cell Locator files.
 
@@ -85,6 +93,12 @@ class Converter(abc.ABC):
     ...     annotation.name = annotation.name.lower()
     >>> data = converter.specialize(data)
     """
+
+    @classproperty
+    def version(cls):
+        file = inspect.getfile(cls)
+        version = Path(file).stem.lstrip('v')
+        return version
 
     @classmethod
     @abc.abstractmethod

--- a/Scripts/convert/version-changlist.md
+++ b/Scripts/convert/version-changlist.md
@@ -9,7 +9,6 @@
 + TextList_Count 0
 ```
 
-
 # 2019-01-26 -> 2020-04-16
 
 2020-04-16, 2020-04-30, and 2020-08-26 all use the same format.
@@ -119,3 +118,9 @@ Major Change
 +         units?
 ```
 
+# 2021-06-08 -> 2021-06-11
+
+```diff
+! markups[]
+-     measurements
+```

--- a/Scripts/convert/versions/v0.0.0+2019.01.26.py
+++ b/Scripts/convert/versions/v0.0.0+2019.01.26.py
@@ -40,9 +40,9 @@ class Converter(model.Converter):
         return doc
 
     @classmethod
+    @model.versioned
     def specialize(cls, doc: model.Document):
         data = dict()
-        data['version'] = cls.version
 
         data["Locked"] = 0
         data["MarkupLabelFormat"] = "%N-%d"

--- a/Scripts/convert/versions/v0.0.0+2019.01.26.py
+++ b/Scripts/convert/versions/v0.0.0+2019.01.26.py
@@ -1,5 +1,6 @@
 import model
 
+
 class Converter(model.Converter):
     @classmethod
     def normalize(cls, data: dict):
@@ -41,7 +42,7 @@ class Converter(model.Converter):
     @classmethod
     def specialize(cls, doc: model.Document):
         data = dict()
-        data['version'] = '0.0.0+2019.01.26'
+        data['version'] = cls.version
 
         data["Locked"] = 0
         data["MarkupLabelFormat"] = "%N-%d"

--- a/Scripts/convert/versions/v0.0.0+2020.04.16.py
+++ b/Scripts/convert/versions/v0.0.0+2020.04.16.py
@@ -52,9 +52,9 @@ class Converter(model.Converter):
         return doc
 
     @classmethod
+    @model.versioned
     def specialize(cls, doc: model.Document):
         data = dict()
-        data['version'] = cls.version
 
         data["DefaultCameraPosition"] = doc.camera_position
         data["DefaultCameraViewUp"] = doc.camera_view_up

--- a/Scripts/convert/versions/v0.0.0+2020.04.16.py
+++ b/Scripts/convert/versions/v0.0.0+2020.04.16.py
@@ -54,7 +54,7 @@ class Converter(model.Converter):
     @classmethod
     def specialize(cls, doc: model.Document):
         data = dict()
-        data['version'] = '0.0.0+2020.04.16'
+        data['version'] = cls.version
 
         data["DefaultCameraPosition"] = doc.camera_position
         data["DefaultCameraViewUp"] = doc.camera_view_up

--- a/Scripts/convert/versions/v0.0.0+2020.08.26.py
+++ b/Scripts/convert/versions/v0.0.0+2020.08.26.py
@@ -36,7 +36,7 @@ class Converter(model.Converter):
     @classmethod
     def specialize(cls, doc: model.Document):
         data = dict()
-        data['version'] = '0.0.0+2020.08.26'
+        data['version'] = cls.version
         data['markups'] = [
             {
                 'markup': {

--- a/Scripts/convert/versions/v0.0.0+2020.08.26.py
+++ b/Scripts/convert/versions/v0.0.0+2020.08.26.py
@@ -34,9 +34,9 @@ class Converter(model.Converter):
         return doc
 
     @classmethod
+    @model.versioned
     def specialize(cls, doc: model.Document):
         data = dict()
-        data['version'] = cls.version
         data['markups'] = [
             {
                 'markup': {

--- a/Scripts/convert/versions/v0.1.0+2020.09.18.py
+++ b/Scripts/convert/versions/v0.1.0+2020.09.18.py
@@ -36,9 +36,9 @@ class Converter(model.Converter):
         return doc
 
     @classmethod
+    @model.versioned
     def specialize(cls, doc: model.Document):
         data = dict()
-        data['version'] = cls.version
         data['markups'] = [
             {
                 'markup': {

--- a/Scripts/convert/versions/v0.1.0+2020.09.18.py
+++ b/Scripts/convert/versions/v0.1.0+2020.09.18.py
@@ -18,10 +18,12 @@ class Converter(model.Converter):
             ann = model.Annotation()
             ann.name = dann['name']
             ann.orientation = dann['orientation']
-            ann.representation_type = dann['representationType']
-            ann.thickness = dann['thickness']
-
             ann.markup_type = dmark['type']
+
+            if ann.markup_type == 'ClosedCurve':
+                ann.representation_type = dann['representationType']
+                ann.thickness = dann['thickness']
+
             ann.coordinate_system = dmark['coordinateSystem']
             if 'coordinateUnits' in dmark:
                 ann.coordinate_units = dmark['coordinateUnits']

--- a/Scripts/convert/versions/v0.1.0+2020.09.18.py
+++ b/Scripts/convert/versions/v0.1.0+2020.09.18.py
@@ -36,7 +36,7 @@ class Converter(model.Converter):
     @classmethod
     def specialize(cls, doc: model.Document):
         data = dict()
-        data['version'] = '0.1.0+2020.09.18'
+        data['version'] = cls.version
         data['markups'] = [
             {
                 'markup': {

--- a/Scripts/convert/versions/v0.1.1+2021.06.11.py
+++ b/Scripts/convert/versions/v0.1.1+2021.06.11.py
@@ -36,7 +36,7 @@ class Converter(model.Converter):
     @classmethod
     def specialize(cls, doc: model.Document):
         data = dict()
-        data['version'] = '0.1.1+2021.06.11'
+        data['version'] = cls.version
         data['markups'] = [
             {
                 'markup': {

--- a/Scripts/convert/versions/v0.1.1+2021.06.11.py
+++ b/Scripts/convert/versions/v0.1.1+2021.06.11.py
@@ -36,14 +36,13 @@ class Converter(model.Converter):
     @classmethod
     def specialize(cls, doc: model.Document):
         data = dict()
-        data['version'] = '0.1.0+2020.09.18'
+        data['version'] = '0.1.1+2021.06.11'
         data['markups'] = [
             {
                 'markup': {
                     'type': ann.markup_type,
                     'coordinateSystem': ann.coordinate_system,
                     'coordinateUnits': ann.coordinate_units,
-                    'measurements': [],  # included to avoid `null` value
                     'controlPoints': [
                         {
                             'id': str(i),

--- a/Scripts/convert/versions/v0.1.1+2021.06.11.py
+++ b/Scripts/convert/versions/v0.1.1+2021.06.11.py
@@ -36,9 +36,9 @@ class Converter(model.Converter):
         return doc
 
     @classmethod
+    @model.versioned
     def specialize(cls, doc: model.Document):
         data = dict()
-        data['version'] = cls.version
         data['markups'] = [
             {
                 'markup': {

--- a/Scripts/convert/versions/v0.1.1+2021.06.11.py
+++ b/Scripts/convert/versions/v0.1.1+2021.06.11.py
@@ -18,10 +18,12 @@ class Converter(model.Converter):
             ann = model.Annotation()
             ann.name = dann['name']
             ann.orientation = dann['orientation']
-            ann.representation_type = dann['representationType']
-            ann.thickness = dann['thickness']
-
             ann.markup_type = dmark['type']
+
+            if ann.markup_type == 'ClosedCurve':
+                ann.representation_type = dann['representationType']
+                ann.thickness = dann['thickness']
+
             ann.coordinate_system = dmark['coordinateSystem']
             if 'coordinateUnits' in dmark:
                 ann.coordinate_units = dmark['coordinateUnits']


### PR DESCRIPTION
I made these changes a few weeks ago while I was working on the conversion script, but never got to merging them into master. The changes are relevant to #182.

~~Cell Locator can't load a file if `Measurements` is `None`, but it *can* if it's not present. Since we don't use Measurements, I just remove them from the serialization output.~~ After more discussion in the linked issue, it seems this may not be true. I'm rebuilding the same version and will do some more testing.

To shield us from similar issues in the future I've also inverted the serialization logic; rather than deleting fields we don't want, I copy the fields we do. This way if we update Slicer and inadvertently bring in new attributes to the markups output, we won't break things like this.

---

I've bumped the file format version number; I need to also add a converter so the broken files can be updated once we cut another release. I'll move the PR out of draft once that's done.

---

I've tested the new converter with the issue described in #182. All converters ignore the `"measurements"` value as input; the difference is in the output from each converter. Targeting version `v0.1.0+2020.09.18` will _unconditionally add_ `"measurements": []`. Targeting version `v0.1.1+2021.06.11` will _unconditionally remove_ the `"measurements"` key.

Both approaches _should_ be compatible with the current release of Cell Locator, however since there are some unexpected problems in the #182 I think this approach makes sense. Moving forward, we don't want Cell Locator's format to be aware of the `"measurements"` key; however the current version should use an empty list just in case.

```bash
# remove "measurements"
python convert.py -v '0.1.0' -t '0.1.1' 'bad_file.json' 'output.json'

# set "measurements": []
python convert.py -v '0.1.0' -t '0.1.0' 'bad_file.json' 'output.json'
```