### PR TITLE
FIX: Annotation initialization should trigger update

### DIFF
--- a/Modules/Scripted/Home/Home.py
+++ b/Modules/Scripted/Home/Home.py
@@ -328,6 +328,8 @@ class AnnotationManager:
     itemId = sh.GetItemByDataNode(annotation.markup)
     tv.setCurrentItem(itemId)
 
+    annotation.update()
+
   @property
   def currentIdx(self):
     """The index of the current annotation in self.annotations"""
@@ -629,6 +631,11 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.updateGUIFromMRML()
     self.updateCameraFromAnnotations()
     self.updateSliceFromAnnotations()
+
+    # now that the annotations are loaded and added to the scene, update each one to
+    # ensure synchronization.
+    for annotation in annotations.annotations:
+      annotation.update()
 
     self.setInteractionState('explore')
 


### PR DESCRIPTION
Trigger `Annotation.update()` after an annotation is loaded.

Fixes #184 .

---

`Annotation.update()` is where the annotation type is updated. Since that was not being invoked when the annotation is loaded, all annotations appeared as splines.
