### PR TITLE
FIX: GUI desync with multiple annotations

### DIFF
--- a/Modules/Scripted/Home/Home.py
+++ b/Modules/Scripted/Home/Home.py
@@ -1036,8 +1036,11 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.get('ContrastSlider').setValues(self.logic.DefaultWindowLevelMin, self.logic.DefaultWindowLevelMax)
 
   def onThicknessChanged(self, value):
-    self.Annotations.current.thickness = value
-    self.Annotations.current.update()
+    if self.Annotations.current:
+      self.Annotations.current.thickness = value
+      self.Annotations.current.update()
+
+    ClosedCurveAnnotation.DefaultThickness = value
 
   def onAnnotationTypeChanged(self):
     if self.get('SplineRadioButton').checked:
@@ -1045,8 +1048,11 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     else:
       representationType = 'polyline'
 
-    self.Annotations.current.representationType = representationType
-    self.Annotations.current.update()
+    if self.Annotations.current:
+      self.Annotations.current.representationType = representationType
+      self.Annotations.current.update()
+
+    ClosedCurveAnnotation.DefaultRepresentationType = representationType
 
   def onSliceNodeModifiedEvent(self, caller=None, event=None):
     sliceNode = caller
@@ -1648,6 +1654,8 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     # other nodes are added to the subject hierarchy.
     if not self.Annotations or not self.Annotations.current:
       return
+
+    self.updateGUIFromAnnotation()
 
     # We need to re-initialize the interaction mode for the current markup. The easiest way is to go to explore, then
     # back to the original mode. If the mode already is explore, then nothing will happen. That's okay, since explore

--- a/Modules/Scripted/Home/Home.py
+++ b/Modules/Scripted/Home/Home.py
@@ -990,6 +990,7 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     sliceWidget = self.LayoutManager.sliceWidget("Slice")
     self.get("SliceOffsetSlider", sliceWidget).singleStep = spacing
 
+    AnnotationManager.DefaultStepSize = spacing
     self.Annotations.stepSize = spacing
 
   def onMarkupsAnnotationStorageNodeModifiedEvent(self):
@@ -1020,6 +1021,7 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     self.resetCamera()
 
+    AnnotationManager.DefaultReferenceView = orientation
     self.Annotations.referenceView = orientation
 
   def onContrastValuesChanged(self, minValue, maxValue):
@@ -1688,6 +1690,7 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     shItemID = shPluginHandler.subjectHierarchyNode().GetItemByDataNode(annotation)
     shPluginHandler.getOwnerPluginForSubjectHierarchyItem(shItemID).setDisplayVisibility(shItemID, visible)
 
+    AnnotationManager.DefaultOntology = ontology
     self.Annotations.ontology = ontology
 
   def onCursorPositionModifiedEvent(self, caller=None, event=None):


### PR DESCRIPTION
GUI could get desynced from annotations. Make a couple changes to fix
this:

- New annotations will use the current annotation's `thickness` and
  `representationType` values (updates `DefaultThickness` and
  `DefaultRepresentationType`)
- Switching to an existing annotation will update the GUI to show its
  `thickness` and `representationType`

Fixes #179, Fixes #180