### PR TITLE
FIX: Changing ontology resets orientation of Slice view.

### DIFF
--- a/Modules/Scripted/Home/Home.py
+++ b/Modules/Scripted/Home/Home.py
@@ -1675,6 +1675,11 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       annotation.GetDisplayNode().SetAndObserveColorNodeID(colorNodeID)
       visible = 1
 
+    # this is the only way to disable view resetting short of reimplementing
+    # qSlicerSubjectHierarchyLabelMapsPlugin::showLabelMapInAllViews. see Slicer/Slicer
+    # Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.cxx#L448-L472
+    qt.QSettings().setValue('SubjectHierarchy/ResetViewOrientationOnShowVolume', False)
+
     # Hide or show label map
     shPluginHandler = slicer.qSlicerSubjectHierarchyPluginHandler.instance()
     shItemID = shPluginHandler.subjectHierarchyNode().GetItemByDataNode(annotation)


### PR DESCRIPTION
Set `QSettings` `SubjectHierarchy/ResetViewOrientationOnShowVolume` to `False`.

See https://github.com/Slicer/Slicer/blob/ebb9303b538495e75519126648b5e621d3f7dc97/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.cxx#L432-L463


> ```c++
> bool resetOrientation = d->resetViewOrientationOnShow();
> bool resetFov = d->resetFieldOfViewOnShow();
> ```
> 
> ```c++
> if (resetOrientation)
>   {
>     // Set to default orientation before rotation so that the view is snapped
>     // closest to the default orientation of this slice view.
>     sliceNode->SetOrientationToDefault();
> ```
> 

Fixes #178