### PR TITLE
DOC: Document double-click action to rename annotations.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,12 @@ Features:
 
 Fixes:
 
+- Don't show exit confirmation when file (or LIMS specimen) is unchanged. [#204](https://github.com/BICCN/cell-locator/pull/204)
+
 Documentation:
+
+- Document double-click action to rename annotations. [#206](https://github.com/BICCN/cell-locator/pull/206)
+- Update expected Slice Offset values in QA template. [#203](https://github.com/BICCN/cell-locator/pull/204); see [#139 (comment)](https://github.com/BICCN/cell-locator/issues/139#issuecomment-916986725) for details.
 
 ## Cell Locator 0.2.0 2021-08-12
 

--- a/Documentation/user_guide/user_interface.md
+++ b/Documentation/user_guide/user_interface.md
@@ -83,6 +83,12 @@ or loading a annotation._
 | Slice Step Size       | 1                    | 10                       |
 | Slice Offset          | `<slice step size>`  | `<slice step size> * 10` |
 
+### Annotation List
+
+| Action                       | Effect               |
+|------------------------------|----------------------|
+| Double-click annotation name | Edit annotation name |
+
 ## LIMS integration
 
 Support is enabled specifying command-line flags `--lims-specimen-id` and `--lims-base-url`.


### PR DESCRIPTION
Added a new table for the "Annotation list" since there is no existing section for that UI element. 

Currently the only actions are double-click rename and the visibility toggle button (which does not currently hide the annotation model).

Resolves #201