### PR TITLE
208 structure info

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 Features:
 
+- Add structure ID and acronym to JSON format. [#208](https://github.com/BICCN/cell-locator/issues/208)
+
 Fixes:
 
 - Don't show exit confirmation when file (or LIMS specimen) is unchanged. [#204](https://github.com/BICCN/cell-locator/pull/204)

--- a/Documentation/developer_guide/AnnotationFileFormat.md
+++ b/Documentation/developer_guide/AnnotationFileFormat.md
@@ -10,6 +10,10 @@ We mean it.
 
 ## Versions
 
+## Next Release
+
+Add the `structure` object to control point. `null` for values with missing structure (outside of atlas, converted from old file, etc.)
+
 ## 0.2.0 (2021-08-11)
 
 Unchanged from 0.1.1; this version synchronizes the file format and cell locator release.

--- a/Scripts/convert/converters.py
+++ b/Scripts/convert/converters.py
@@ -13,6 +13,7 @@ version_root = Path(__file__).parent.joinpath('versions')
 
 # most-recent versions first
 version_order = [
+    'v0.2.1+2022.03.04',
     'v0.2.0+2021.08.12',
     'v0.1.1+2021.06.11',
     'v0.1.0+2020.09.18',

--- a/Scripts/convert/model.py
+++ b/Scripts/convert/model.py
@@ -3,7 +3,7 @@ import dataclasses
 import inspect
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
 __all__ = ['Annotation', 'Document', 'Converter', 'versioned']
 
@@ -13,6 +13,19 @@ Matrix4f = Tuple[float, float, float, float,
                  float, float, float, float,
                  float, float, float, float]
 
+@dataclass
+class Structure:
+    id: int
+    acronym: str
+
+@dataclass
+class Point:
+    position: Vector3f
+    structure: Optional[Structure] = None
+
+    def __iter__(self):
+        # enables unpacking like `x, y, z = point`
+        return iter(self.position)
 
 @dataclass
 class Annotation:
@@ -40,7 +53,7 @@ class Annotation:
     )
     """A transformation matrix storing the orientation of the slicing plane."""
 
-    points: List[Vector3f] = dataclasses.field(default_factory=list)
+    points: List[Point] = dataclasses.field(default_factory=list)
     """Control point positions for the annotation markup."""
 
 

--- a/Scripts/convert/versions/v0.0.0+2019.01.26.py
+++ b/Scripts/convert/versions/v0.0.0+2019.01.26.py
@@ -27,7 +27,7 @@ class Converter(model.Converter):
 
             ann.coordinate_system = 'LPS'
             ann.points = [
-                (-p['x'], -p['y'], p['z'])  # RAS → LPS conversion
+                model.Point((-p['x'], -p['y'], p['z']))  # RAS → LPS conversion
                 for p in dmark['Points']
             ]
 

--- a/Scripts/convert/versions/v0.0.0+2020.04.16.py
+++ b/Scripts/convert/versions/v0.0.0+2020.04.16.py
@@ -39,7 +39,7 @@ class Converter(model.Converter):
 
             ann.coordinate_system = 'LPS'
             ann.points = [
-                (-p['x'], -p['y'], p['z'])  # RAS → LPS conversion
+                model.Point((-p['x'], -p['y'], p['z']))  # RAS → LPS conversion
                 for p in dmark['Points']
             ]
 

--- a/Scripts/convert/versions/v0.0.0+2020.08.26.py
+++ b/Scripts/convert/versions/v0.0.0+2020.08.26.py
@@ -27,7 +27,7 @@ class Converter(model.Converter):
                 ann.coordinate_units = dmark['coordinateUnits']
 
             for point in dmark['controlPoints']:
-                ann.points.append(tuple(point['position']))
+                ann.points.append(model.Point(tuple(point['position'])))
 
             doc.annotations.append(ann)
 
@@ -50,7 +50,7 @@ class Converter(model.Converter):
                             'label': f'MarkupsClosedCurve-{i}',
                             'description': '',
                             'associatedNodeID': 'vtkMRMLScalarVolumeNode1',
-                            'position': pt,
+                            'position': pt.position,
                             'orientation': [-1.0, -0.0, -0.0,
                                             -0.0, -1.0, -0.0,
                                             +0.0, +0.0, +1.0],

--- a/Scripts/convert/versions/v0.1.0+2020.09.18.py
+++ b/Scripts/convert/versions/v0.1.0+2020.09.18.py
@@ -29,7 +29,7 @@ class Converter(model.Converter):
                 ann.coordinate_units = dmark['coordinateUnits']
 
             for point in dmark['controlPoints']:
-                ann.points.append(tuple(point['position']))
+                ann.points.append(model.Point(tuple(point['position'])))
 
             doc.annotations.append(ann)
 
@@ -49,7 +49,7 @@ class Converter(model.Converter):
                     'controlPoints': [
                         {
                             'id': str(i),
-                            'position': pt,
+                            'position': pt.position,
                             'orientation': [-1.0, -0.0, -0.0,
                                             -0.0, -1.0, -0.0,
                                             +0.0, +0.0, +1.0]

--- a/Scripts/convert/versions/v0.2.0+2021.08.12.py
+++ b/Scripts/convert/versions/v0.2.0+2021.08.12.py
@@ -29,7 +29,7 @@ class Converter(model.Converter):
                 ann.coordinate_units = dmark['coordinateUnits']
 
             for point in dmark['controlPoints']:
-                ann.points.append(tuple(point['position']))
+                ann.points.append(model.Point(tuple(point['position'])))
 
             doc.annotations.append(ann)
 
@@ -48,7 +48,7 @@ class Converter(model.Converter):
                     'controlPoints': [
                         {
                             'id': str(i),
-                            'position': pt,
+                            'position': pt.position,
                             'orientation': [-1.0, -0.0, -0.0,
                                             -0.0, -1.0, -0.0,
                                             +0.0, +0.0, +1.0]

--- a/Scripts/convert/versions/v0.2.1+2022.03.04.py
+++ b/Scripts/convert/versions/v0.2.1+2022.03.04.py
@@ -29,7 +29,15 @@ class Converter(model.Converter):
                 ann.coordinate_units = dmark['coordinateUnits']
 
             for point in dmark['controlPoints']:
-                ann.points.append(model.Point(tuple(point['position'])))
+                position = tuple(point['position'])
+                structure = point.get('structure', None)
+                if structure:
+                    structure = model.Structure(
+                        structure['id'],
+                        structure['acronym'],
+                    )
+
+                ann.points.append(model.Point(position, structure))
 
             doc.annotations.append(ann)
 
@@ -51,7 +59,11 @@ class Converter(model.Converter):
                             'position': pt.position,
                             'orientation': [-1.0, -0.0, -0.0,
                                             -0.0, -1.0, -0.0,
-                                            +0.0, +0.0, +1.0]
+                                            +0.0, +0.0, +1.0],
+                            'structure': {
+                                'id': pt.structure.id,
+                                'acronym': pt.structure.acronym
+                            } if pt.structure else None
                         }
                         for i, pt in enumerate(ann.points, start=1)
                     ],


### PR DESCRIPTION
Adds `structure` to each control point in JSON output. This value is ignored during file loading, only used as metadata in consuming applications. Resolves #208. Note this change requires each `Annotation` instance hold a reference to the `HomeLogic` instance. Looking toward #196, it may make sense to introduce a "AtlasLogic" or similar which contains the volume node, color node, and related metadata _for only one atlas_. This metadata could then be serialized within `Annotation.toDict`.

Adds methods to HomeLogic

- `getWorldRASToIJKTransform`
- `getAllenLabelIndex`
- `getAnnotation`

Updates `getCrosshairPixelString` and `getPixelString` to use them.

Those methods, along with these attributes, could probably go in an `AtlasLogic` class:

- `AllenStructurePaths`
- `AllenLayerStructurePaths`
- `AllenStructureNames`
- `SlicerToAllenMapping`
- `AllenToSlicerMapping`