### PR TITLE
Update docs

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,23 +1,13 @@
 # Build and Package CellLocator
 
-This document summarizes how to build and package CellLocator on Windows. Instructions for
-Linux and macOS are similar. For more details, see [3D Slicer Developer Wiki](http://wiki.slicer.org/slicerWiki/index.php/Documentation/Nightly/Developers).
+This document summarizes how to build and package CellLocator on Windows.
+
+Cell Locator is a custom Slicer application. Reading the [3D Slicer Developer Documentation](https://slicer.readthedocs.io/en/latest/developer_guide/index.html) may help answer additional questions.
+
+The initial source files were created using [KitwareMedical/SlicerCustomAppTemplate](https://github.com/KitwareMedical/SlicerCustomAppTemplate).
 
 
 ## Prerequisites
-
-* Microsoft Windows 7 or above recommended
-
-* Supported Microsoft Visual Studio versions:
-    * Visual Studio 2015
-
-* [CMake](http://cmake.org/cmake/resources/software.html), version 3.11 or above
-
-* Qt, version 5.10 or above
-
-* [Git](http://git-scm.com/downloads)
-
-* [Subversion](http://www.sliksvn.com/en/download)
 
 * Setting up your git account:
 
@@ -28,6 +18,9 @@ Linux and macOS are similar. For more details, see [3D Slicer Developer Wiki](ht
 
     * Setup [your git username](https://help.github.com/articles/setting-your-username-in-git) and [your git email](https://help.github.com/articles/setting-your-email-in-git).
 
+    * If not already done, email `Lydia Ng <LydiaN@alleninstitute.org>` to be granted access to
+    the [BICCN/cell-locator](https://github.com/BICCN/cell-locator) repository.
+
 ## Checkout
 
 1. Start [Git Bash](https://help.github.com/articles/set-up-git#need-a-quick-lesson-about-terminalterminalgit-bashthe-command-line)
@@ -37,7 +30,7 @@ Linux and macOS are similar. For more details, see [3D Slicer Developer Wiki](ht
 cd /c
 mkdir W
 cd /c/W
-git clone https://github.com/BICCN/cell-locator.git cell-locator
+git clone https://github.com/BICCN/cell-locator.git CL
 ```
 
 Note: use short source and build directory names to avoid the [maximum path length limitation](http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247%28v=vs.85%29.aspx#maxpath).
@@ -48,21 +41,21 @@ Note: The build process will take approximately 3 hours.
 
 <b>Option 1: CMake GUI and Visual Studio (Recommended)</b>
 
-1. Start [CMake GUI](https://cmake.org/runningcmake/), select source directory `C:\W\cell-locator` and set build directory to `C:\W\cell-locator-rel`.
-2. Add an entry `QT_QMAKE_EXECUTABLE` pointing to `C:\D\Support\qt-4.8.7-64-vs2013-rel`.
+1. Start [CMake GUI](https://cmake.org/runningcmake/), select source directory `C:\W\CL` and set build directory to `C:\W\CLR`.
+2. Add an entry `Qt5_DIR` pointing to `C:/Qt/${QT_VERSION}/${COMPILER}/lib/cmake/Qt5`.
 2. Generate the project.
-3. Open `C:\W\cell-locator-rel\CellLocator.sln`, select `Release` and build the project.
+3. Open `C:\W\CLR\CellLocator.sln`, select `Release` and build the project.
 
 <b>Option 2: Command Line</b>
 
 1. Start the [Command Line Prompt](http://windows.microsoft.com/en-us/windows/command-prompt-faq)
-2. Configure and build the project in `C:\W\cell-locator-rel` by typing the following commands:
+2. Configure and build the project in `C:\W\CLR` by typing the following commands:
 
 ```bat
 cd C:\W\
-mkdir cell-locator-rel
-cd cell-locator-rel
-cmake -G "Visual Studio 14 2015 Win64" -DQT_QMAKE_EXECUTABLE:PATH=C:\Qt\5.9.1\msvc2015_64\bin\qmake.exe ..\cell-locator
+mkdir CLR
+cd CLR
+cmake -G "Visual Studio 16 2019" -A x64 -DQt5_DIR:PATH=`C:/Qt/${QT_VERSION}/${COMPILER}/lib/cmake/Qt5 ..\CL
 cmake --build . --config Release
 ```
 
@@ -72,7 +65,7 @@ Install [NSIS 2](http://sourceforge.net/projects/nsis/files/)
 
 <b>Option 1: CMake and Visual Studio (Recommended)</b>
 
-1. In the `C:\W\cell-locator-rel\Slicer-build` directory, open `Slicer.sln` and build the `PACKAGE` target
+1. In the `C:\W\CLR\Slicer-build` directory, open `Slicer.sln` and build the `PACKAGE` target
 
 <b>Option 2: Command Line</b>
 
@@ -80,6 +73,6 @@ Install [NSIS 2](http://sourceforge.net/projects/nsis/files/)
 2. Build the `PACKAGE` target by typing the following commands:
 
 ```bat
-cd C:\W\cell-locator-rel\Slicer-build
+cd C:\W\CLR\Slicer-build
 cmake --build . --config Release --target PACKAGE
 ```

--- a/Documentation/app-overview.md
+++ b/Documentation/app-overview.md
@@ -62,6 +62,16 @@ To show or hide an annotation in both viewers, the user may click on the eye ico
 
 ### Property Editor
 
+* **Slice Step Size** configures how the [2D Viewer](#2d-viewer) slicer offset may be adjusted.
+* **Annotation Thickess** updates the width of selected `Curve` annotation.
+* **Annotation Type** updates how the annotation is represented in both viewers.
+
+:::{admonition} Numeric Inputs
+:class: tip
+
+After clicking in either the **Slice Step Size** or **Annotation Thickess** spin box, its value may be updated using a "large" step as described in the [Numeric Inputs](#numeric-inputs) keyboard shortcuts.
+:::
+
 ### Status Bar
 
 ## Keyboard and Mouse Shortcuts

--- a/Documentation/app-overview.md
+++ b/Documentation/app-overview.md
@@ -56,6 +56,14 @@ To show or hide an annotation in both viewers, the user may click on the eye ico
 
 ### Interaction Modes
 
+* **Explore** mode allows to interact with the viewers without updating the orientation of the currently selected annotation.
+* **Edit** mode allows to update the selected annotation.
+  * Position and size can be updated in the [2D Viewer](#2d-viewer).
+  * Orientation can be updated in the [3D Viewer](#3d-viewer) by using the reformat widget or by setting specific angles.
+* **Place** mode allows to add point(s) to the currently selected annotation by clicking one the slice displayed in the [2D Viewer](#2d-viewer).
+
+<img src="https://github.com/BICCN/cell-locator/releases/download/docs-resources/app_interaction_mode.png" width="50%" align="center" class="no-scaled-link"/>
+
 ### 2D Viewer
 
 ### 3D Viewer
@@ -94,7 +102,7 @@ The user will be prompted with a save dialog before overwriting unsaved changes.
 
 ### 2D Viewer - Zoom and Pan
 
-These interactions are enabled only in Exploration and Edit mode.
+These interactions are enabled only in _Explore_ and _Edit_ mode.
 
 | Interface Device | Zoom                              | Pan                       |
 |------------------|-----------------------------------|---------------------------|
@@ -105,7 +113,7 @@ These interactions are enabled only in Exploration and Edit mode.
 
 ### 2D Viewer - Annotation
 
-These interactions are enabled only in Edit and Place modes.
+These interactions are enabled only in _Edit_ and _Place_ modes.
 
 | Key or mouse operation                      | Effect                                     |
 |---------------------------------------------|--------------------------------------------|

--- a/Documentation/app-overview.md
+++ b/Documentation/app-overview.md
@@ -30,6 +30,14 @@ Starting the application specifying the `--atlas-type` [command-line argument](#
 
 ### Lifecycle
 
+* **New** allows to create a new annotation file.
+* **Save** and **Save As** allow to save the current annotation(s) to file.
+* **Load** allows to load annotation(s) from file.
+
+:::{warning}
+If the current annotation(s) have been modified, the user is asked if they should be saved to file before creating or loading new ones.
+:::
+
 ### Annotation List
 
 ### Interaction Modes

--- a/Documentation/app-overview.md
+++ b/Documentation/app-overview.md
@@ -155,10 +155,19 @@ These interactions are enabled only in _Edit_ and _Place_ modes.
 |---------------------------------------------|--------------------------------------------|
 | `Left-Click` on annotation line             | Add annotation point                       |
 | `Right-Click` on point then `Delete`        | Delete currently selected annotation point |
+| `Right-Click` on point then `Interaction`    | Show/hide the interaction widget           |
 | `Ctrl + Left-Click` on annotation line      | Insert annotation point                    |
 | Drag `Alt + Left-Click` on annotation line  | Rotate annotation                          |
 | Drag `Alt + Right-Click` on annotation line | Scale annotation                           |
 | Drag `Middle-Click` on annotation line      | Translate annotation                       |
+
+:::{figure-md}
+:align: center
+
+<img src="https://github.com/BICCN/cell-locator/releases/download/docs-resources/app_2dviewer_point_right_click_context_menu.png" width="75%" align="center" class="no-scaled-link"/>
+
+Annotation point right-click context menu.
+:::
 
 ### Numeric Inputs
 

--- a/Documentation/app-overview.md
+++ b/Documentation/app-overview.md
@@ -66,7 +66,26 @@ To show or hide an annotation in both viewers, the user may click on the eye ico
 
 ### 2D Viewer
 
+The 2D viewer (or slice viewer) allows to create or edit annotations on the viewing plane. The slice orientation allows to change the reference from which row, pitch and yaw angles are set in the 3D viewer.
+
+<img src="https://github.com/BICCN/cell-locator/releases/download/docs-resources/app_2dviewer.png" width="75%" align="center" class="no-scaled-link"/>
+
+* **Slice offset slider** allows slicing through the atlas reference volume. Step size is set in the [Property Editor](#property-editor).
+* **Adjust field of view** centers the slice viewer's field of view to match the extent of the atlas reference volume.
+* **Slice orientation** allows to choose the orientation of the slice in the 2D and [3D Viewer](#3d-viewer).
+* **Contrast slider** allows to adjust the grayscale background contrast associated with the atlas reference volume.
+* **Reset contrast** allows to reset the grayscale background contrast associated with the atlas reference volume
+
 ### 3D Viewer
+
+The 3D viewer provides an interface to update the slice viewer plane orientation.
+
+<img src="https://github.com/BICCN/cell-locator/releases/download/docs-resources/app_3dviewer.png" width="75%" align="center" class="no-scaled-link"/>
+
+* **Raw**, **Pitch** and **Yaw** sliders and input boxes allow to set the [2D Viewer](#2d-viewer) plane angles relative to the selected slice orientation (Axial, Coronal or Sagittal).
+* **Apply** allows to update the slice orientaton based on the set angles.
+* **Reset** allows to reset the angles to match the slice orientation selected in the 2D Viewer.
+* **Reformat widget** allows to update the slice orientation.
 
 ### Property Editor
 

--- a/Documentation/app-overview.md
+++ b/Documentation/app-overview.md
@@ -1,5 +1,29 @@
 # Application Overview
 
+## Atlas Selection
+
+After starting Cell Locator, the user is prompted with a dialog asking to choose which [reference atlas](reference-atlases.md) to load.
+
+:::{admonition} Resetting Views
+:class: tip
+
+The `Ctrl + w` keyboard shortcut allows to reset views discarding current changes and asking to choose which reference atlas to load.
+:::
+
+:::{figure-md}
+:align: center
+
+<img src="https://github.com/BICCN/cell-locator/releases/download/docs-resources/app_atlas_selection_dialog.png" width="50%" class="no-scaled-link"/>
+
+Atlas Selection Startup Dialog
+:::
+
+:::{admonition} Automatic Atlas Selection
+:class: tip
+
+Starting the application specifying the `--atlas-type` [command-line argument](#general-options) will skip the atlas selection startup dialog and directly load the requested altas. In this case, resetting the views also skips the atlas selection dialog.
+:::
+
 ## User Interface
 
 ## Keyboard and Mouse Shortcuts

--- a/Documentation/app-overview.md
+++ b/Documentation/app-overview.md
@@ -91,8 +91,8 @@ _On macOS use the Command key (⌘) instead of the Control (Ctrl) key_
 | Key        | Effect                                                |
 |------------|-------------------------------------------------------|
 | `Ctrl + n` | Create a new annotation                               |
-| `Ctrl + s` | Save current annotation                               |
-| `Ctrl + o` | Load an annotation from file                          |
+| `Ctrl + s` | Save current annotation(s)                            |
+| `Ctrl + o` | Load annotation(s) from file                          |
 | `Ctrl + w` | Reset views discarding current changes                |
 | `f`        | Increment Slice offset                                |
 | `b`        | Decrement Slice offset                                |

--- a/Documentation/app-overview.md
+++ b/Documentation/app-overview.md
@@ -136,6 +136,7 @@ the `Slice Step Size`.
 | Action                         | Effect               |
 |--------------------------------|----------------------|
 | Double-`Left-Click` annotation | Edit annotation name |
+| `Left-Click` on eye icon       | Show/hide annotation |
 
 ## Command-line arguments
 

--- a/Documentation/app-overview.md
+++ b/Documentation/app-overview.md
@@ -26,6 +26,22 @@ Starting the application specifying the `--atlas-type` [command-line argument](#
 
 ## User Interface
 
+![](https://github.com/BICCN/cell-locator/releases/download/docs-resources/app_overview.png)
+
+### Lifecycle
+
+### Annotation List
+
+### Interaction Modes
+
+### 2D Viewer
+
+### 3D Viewer
+
+### Property Editor
+
+### Status Bar
+
 ## Keyboard and Mouse Shortcuts
 
 _On macOS use the Command key (⌘) instead of the Control (Ctrl) key_

--- a/Documentation/app-overview.md
+++ b/Documentation/app-overview.md
@@ -40,6 +40,20 @@ If the current annotation(s) have been modified, the user is asked if they shoul
 
 ### Annotation List
 
+To to add, remove or duplicate an annotation, the user may click on the corresponding button:
+
+* **Add Curve** and **Add Point** allow to add an annotation.
+* **Clone** allows to duplicate the selected annotation.
+* **Remove** allows to delete the selected annotation.
+
+To rename an annotation, the user may Double-`Left-Click` on its name.
+
+To show or hide an annotation in both viewers, the user may click on the eye icon.
+
+:::{note}
+* A `Curve` annotation is expected to have multiple points and the corresponding type can be set using the [Property Editor](#property-editor).
+:::
+
 ### Interaction Modes
 
 ### 2D Viewer

--- a/Documentation/app-overview.md
+++ b/Documentation/app-overview.md
@@ -82,6 +82,23 @@ After clicking in either the **Slice Step Size** or **Annotation Thickess** spin
 
 ### Status Bar
 
+* **Ontology Selector** allows to select between `None`, `Structure` and `Layer` (only available for the CFF atlas).
+* **Text** about what is visible at the current mouse pointer position.
+
+The status bar text is formatted as
+  ```
+  x y z | <path> (<label index>)
+  ```
+where:
+  * `x y z` corresponds to the world coordinates (RAS).
+  * `<path>` is formatted as `> structure 1 > structure 2 > ...` (or `> layer 1 > layer 2 > ...`).
+  * `<label index>` corresponds to the value in the annotation volume.
+
+| Ontology  |  Example of text |
+|-----------|---|
+| structure | ![](https://github.com/BICCN/cell-locator/releases/download/docs-resources/app_ontology_structure.png) |
+| layer     | ![](https://github.com/BICCN/cell-locator/releases/download/docs-resources/app_ontology_layer.png) |
+
 ## Keyboard and Mouse Shortcuts
 
 _On macOS use the Command key (⌘) instead of the Control (Ctrl) key_

--- a/Documentation/command-line-tools.md
+++ b/Documentation/command-line-tools.md
@@ -2,7 +2,7 @@
 
 Utility CLI tools for processing Cell Locator annotation files.
 
-For information on extending `cl-convert`, see the [Converter API Documentation](developer-guide/index.md)
+For information on extending `cl-convert`, see the [Converter API Documentation](developer-guide/cl-convert-api.md)
 
 ## Installation
 

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -39,6 +39,7 @@ extensions = [
 
 myst_enable_extensions = [
     "colon_fence",  # Allow code fence using ::: (see https://myst-parser.readthedocs.io/en/latest/using/syntax-optional.html#syntax-colon-fence)
+    "html_image", # Allow using isolated img tags (i.e. not wrapped in any other HTML) to specify attributes like width.
     "linkify",  # Allow automatic creation of links from URLs (it is sufficient to write https://google.com instead of <https://google.com>)
 ]
 

--- a/Documentation/coordinate-systems.md
+++ b/Documentation/coordinate-systems.md
@@ -4,7 +4,7 @@
 
 The table below describes the coordinate systems of the [reference atlases](reference-atlases.md) distributed in Cell Locator.
 
-| Reference atlas                               | Atlas Version | Coordinate System Dimenstions |
+| Reference atlas                               | Atlas Version | Coordinate System Dimensions  |
 |-----------------------------------------------|---------------|-------------------------------|
 | Allen Mouse Brain Common Coordinate Framework | 3             | PIR                           |
 | Allen Human Reference Atlas - 3D              | 1.0.0         | RAS                           |

--- a/Documentation/developer-guide/annotation-file-format.md
+++ b/Documentation/developer-guide/annotation-file-format.md
@@ -43,10 +43,9 @@ If the answer is **yes**, no changes are required.
 
 _The latest version listed below should correspond to the version hard-coded in the ``AnnotationManager.FORMAT_VERSION`` constant set in [Modules/Scripted/Home/Home.py][home-py]._
 
-_Overview of differences between versions are documented in [version-changlist.md][version-changlist]._
+_Overview of differences between versions are documented in the [version changelist](annotation-file-version-changlist.md)._
 
 [home-py]: https://github.com/BICCN/cell-locator/blob/main/Modules/Scripted/Home/Home.py
-[version-changlist]: https://github.com/BICCN/cell-locator/blob/main/cell-locator-cli/version-changlist.md
 
 ### 0.2.1 (2022-03-04)
 

--- a/Documentation/developer-guide/annotation-file-format.md
+++ b/Documentation/developer-guide/annotation-file-format.md
@@ -1,10 +1,12 @@
 # Annotation File Format
 
+:::{warning}
 The Cell Locator annotation format is non-standard and exists purely as an
-implementation detail. While structural changes will be documented, the file
+implementation detail. While we are documenting [structural changes](annotation-file-version-changlist.md) and providing a [converter](command-line-tools.md#tools), the file
 organization may change from version to version without notice.
 
 We mean it.
+:::
 
 ## Modifying the File Format
 

--- a/Documentation/developer-guide/annotation-file-version-changlist.md
+++ b/Documentation/developer-guide/annotation-file-version-changlist.md
@@ -1,0 +1,2 @@
+```{include} ../../cell-locator-cli/version-changlist.md
+```

--- a/Documentation/developer-guide/index.md
+++ b/Documentation/developer-guide/index.md
@@ -6,6 +6,7 @@ building.md
 cell-locator-api.md
 cl-convert-api.md
 annotation-file-format.md
+annotation-file-version-changlist.md
 changelog.md
 contributing.md
 maintainers.md

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-## Installing Cell-Locator
+## Installing Cell Locator
 
 Download the [latest release on GitHub](https://github.com/BICCN/cell-locator/releases/latest)
 
@@ -9,4 +9,62 @@ Download the [latest release on GitHub](https://github.com/BICCN/cell-locator/re
 Cell Locator is built using 3D Slicer, so refer to the 
 [3D Slicer System Requirements](https://slicer.readthedocs.io/en/latest/user_guide/getting_started.html#system-requirements).
 
+:::{admonition} Cross-platform Availability
+:class: tip
+
 Installers are only generated for 64-bit Windows, however it is possible to build Cell Locator from source on any platform which supports 3D Slicer. Refer to the [developer guide](developer-guide/building.md) for build instructions.
+:::
+
+## Using Cell Locator
+
+### Quick Start
+
+After starting Cell Locator, you will choose an atlas.
+
+:::{figure-md}
+:align: center
+
+<img src="https://github.com/BICCN/cell-locator/releases/download/docs-resources/app_atlas_selection_dialog.png" width="50%" class="no-scaled-link"/>
+
+Atlas Selection Startup Dialog
+:::
+
+After selecting an atlas, the application is ready with an annotation named _Curve_ already created.
+
+Before adding points to the annotation:
+
+1. Switch to _Edit_ interaction mode.
+
+2. Use the reformat widget available in the 3D viewer on the right to update the orientation and identify a slice plane of interest.
+
+<img src="https://github.com/BICCN/cell-locator/releases/download/docs-resources/getting_started_1.png" width="80%" align="center" class="no-scaled-link"/>
+
+:::{admonition} Hint
+:class: tip
+
+Alternatively, you may directly set the the raw, pitch and yaw angles.
+:::
+
+You can  switch to _Place_ interaction mode and start adding points to the annotation.
+
+1. Left-Click to add (or place) points.
+
+2. Right-Click to switch back to the _Edit_ interaction mode.
+
+<img src="https://github.com/BICCN/cell-locator/releases/download/docs-resources/getting_started_2.png" width="80%" align="center" class="no-scaled-link"/>
+
+Once you are done adding points, you can update annotation properties.
+
+1. Switch the annotation type from _Spline_ to _PolyLine_.
+
+2. Renane the extension.
+
+<img src="https://github.com/BICCN/cell-locator/releases/download/docs-resources/getting_started_3.png" width="80%" align="center" class="no-scaled-link"/>
+
+Finally, you can save the annotation as a `.json` file by clicking on the _Save_ button.
+
+<img src="https://github.com/BICCN/cell-locator/releases/download/docs-resources/getting_started_4.png" width="80%" align="center" class="no-scaled-link"/>
+
+### User manual
+
+Browse the [Application Overview](app-overview.md) section to learn about the application user interface.

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -6,13 +6,14 @@ Download the [latest release on GitHub](https://github.com/BICCN/cell-locator/re
 
 ## System Requirements
 
-Cell Locator is built using 3D Slicer, so refer to the 
-[3D Slicer System Requirements](https://slicer.readthedocs.io/en/latest/user_guide/getting_started.html#system-requirements).
+Cell Locator is based on 3D Slicer, so refer to the [3D Slicer System Requirements](https://slicer.readthedocs.io/en/latest/user_guide/getting_started.html#system-requirements).
 
 :::{admonition} Cross-platform Availability
 :class: tip
 
-Installers are only generated for 64-bit Windows, however it is possible to build Cell Locator from source on any platform which supports 3D Slicer. Refer to the [developer guide](developer-guide/building.md) for build instructions.
+Installers are only generated for 64-bit Windows, however it is possible to build Cell Locator from source on any platform which supports 3D Slicer.
+
+Refer to the [Cell Locator build instructions](developer-guide/building.md).
 :::
 
 ## Using Cell Locator

--- a/Documentation/index.md
+++ b/Documentation/index.md
@@ -22,8 +22,8 @@ A desktop application based on [3D Slicer](https://slicer.org/) that displays th
 ```{toctree}
 :maxdepth: 2
 :caption: Contents
-app-overview.md
 getting-started.md
+app-overview.md
 reference-atlases.md
 coordinate-systems.md
 lims-integration.md

--- a/cell-locator-cli/version-changlist.md
+++ b/cell-locator-cli/version-changlist.md
@@ -1,4 +1,6 @@
-# Base
+# Annotation File Version Changlist
+
+## Base
 
 ```diff
 + Locked
@@ -9,7 +11,7 @@
 + TextList_Count 0
 ```
 
-# 2019-01-26 -> 2020-04-16
+## 2019-01-26 -> 2020-04-16
 
 2020-04-16, 2020-04-30, and 2020-08-26 all use the same format.
 
@@ -24,7 +26,7 @@
 + DefaultThickness
 ```
 
-# 2020-04-16 -> 2020-08-26
+## 2020-04-16 -> 2020-08-26
 
 Major Change
 
@@ -86,7 +88,7 @@ Major Change
 -     Visibility
 ```
 
-# 2020-08-26 -> 2020-09-18
+## 2020-08-26 -> 2020-09-18
 
 ```diff
 ! markups[]
@@ -105,7 +107,7 @@ Major Change
 -             visibility
 ```
 
-# 2020-09-18 -> 2021-06-08
+## 2020-09-18 -> 2021-06-08
 
 ```diff
 + version
@@ -118,18 +120,18 @@ Major Change
 +         units?
 ```
 
-# 2021-06-08 -> 2021-06-11
+## 2021-06-08 -> 2021-06-11
 
 ```diff
 ! markups[]
 -     measurements
 ```
 
-# 2021-06-11 -> 2021-08-12
+## 2021-06-11 -> 2021-08-12
 
 _Unchanged; this version synchronizes the file format and cell locator release._
 
-# 2021-08-12 -> 2022-03-04
+## 2021-08-12 -> 2022-03-04
 
 ```diff
 ! markups[]


### PR DESCRIPTION
### New

* Add "Getting Started / Using Cell Locator" section

* Add "Application Overview" section with following sub-sections:
  * Atlas Selection
  * User Interface
     * Lifecycle
     * Annotation List
     * Interaction Modes
     * 2D Viewer
     * 3D Viewer
     * Property Editor
     * Status Bar

* Add reference to "Annotation File Version Changlist"

### Updates

* Update "Command Line Tools" to explicitly reference "cl-convert-api.md"
* Improve "Annotation File Format" including links and using warning directive
* Fix "Keyboard and Mouse Shortcuts" to document annotation visibility 
* Fix "Keyboard and Mouse Shortcuts" to account for multi-annotation support
* Set "Getting Started" section as the first one
* Update BUILD instructions
 