### PR TITLE
COMP: Update Slicer and VTK to workaround pthread and dl link errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT DEFINED slicersources_SOURCE_DIR)
   # Download Slicer sources and set variables slicersources_SOURCE_DIR and slicersources_BINARY_DIR
   FetchContent_Populate(slicersources
     GIT_REPOSITORY https://github.com/KitwareMedical/Slicer
-    GIT_TAG        f81033d29c2f8f0373896652ebd0d9c432f2fe46 # cell-locator-v4.11.0-2021-04-01-0d7f7bad74
+    GIT_TAG        008c30e7fe46773998e93c510f02323619419580 # cell-locator-v4.11.0-2021-04-01-0d7f7bad74
     GIT_PROGRESS   1
     )
 else()


### PR DESCRIPTION
List of Slicer updates:

```
$ git shortlog f81033d29c..008c30e7fe --no-merges
Jean-Christophe Fillion-Robin (1):
      [cell-locator] COMP: Update VTK to workaround pthread and dl link errors
```

-----
List of VTK updates:

```
$ git shortlog 97904fdcc7..925473c4fb --no-merges
Jean-Christophe Fillion-Robin (2):
      COMP: Remove FindTBB and expect VTK to be configured with TBB_DIR
      COMP: Workaround pthread and dl link errors when VTK_ENABLE_KITS is ON
```

-----
This commit workarounds the following link errors reported when using gcc 9.4.0 (Ubuntu 20.04).

```
[100%] Linking CXX executable ../../bin/vtkProbeOpenGLVersion
../../lib/libvtkexodusII-8.2.so.1: error: undefined reference to 'pthread_setspecific'
../../lib/libvtkexodusII-8.2.so.1: error: undefined reference to 'pthread_getspecific'
../../lib/libvtkexodusII-8.2.so.1: error: undefined reference to 'pthread_key_create'
../../lib/libvtkexodusII-8.2.so.1: error: undefined reference to 'pthread_mutexattr_settype'
../../lib/libvtkexodusII-8.2.so.1: error: undefined reference to 'pthread_mutexattr_init'
../../lib/libvtkexodusII-8.2.so.1: error: undefined reference to 'pthread_once'
../../lib/libvtkhdf5-8.2.so.1: error: undefined reference to 'dlerror'
../../lib/libvtkhdf5-8.2.so.1: error: undefined reference to 'dlsym'
../../lib/libvtkhdf5-8.2.so.1: error: undefined reference to 'dlopen'
../../lib/libvtkhdf5-8.2.so.1: error: undefined reference to 'dlclose'
```